### PR TITLE
Initial baseten skill

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contributing
+
+## Adding or changing a skill
+
+Each skill is a directory under `skills/`. For skill structure, writing patterns, progressive disclosure, and other conventions, follow:
+
+- The skill creation best practices at <https://agentskills.io/skill-creation/best-practices>.
+- The `skill-creator` skill from <https://github.com/anthropics/skills>, which guides the full create / iterate / evaluate loop.
+
+## Running evals before merging
+
+Skill changes ship with eval results, produced via the `skill-creator` workflow above. Eval definitions (the prompts and their assertions) live alongside the skill at `skills/<name>/evals/evals.json` so they can be re-run against future versions. Raw run artifacts (per-eval outputs, grading JSON, the HTML viewer) belong in a workspace directory outside the repo so the commit history stays focused on the skill and its evals.
+
+## Writing up results
+
+Write a curated summary into `eval-results/<skill>/YYYY-MM-DD.md` and link it from the PR. The summary should let a reviewer judge the change without needing the raw artifacts:
+
+- The prompts that were run (verbatim).
+- The assertions that were checked.
+- For each prompt: with-skill vs. baseline pass rate, tokens, duration, and one or two lines of qualitative observation.
+- Takeaways that drove the changes in the PR.
+
+If multiple iterations happen on the same day, append to the same file. A new day starts a new file.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,8 @@ Each skill is a directory under `skills/`. For skill structure, writing patterns
 - The skill creation best practices at <https://agentskills.io/skill-creation/best-practices>.
 - The `skill-creator` skill from <https://github.com/anthropics/skills>, which guides the full create / iterate / evaluate loop.
 
+Skills are not the authoritative home for any content. If a skill needs a product fact, API detail, or code example that isn't already in docs (docs.baseten.co) or a sample repo, add it there first and have the skill draw from that source. Restating upstream content in a skill is fine; originating it in a skill is not.
+
 ## Running evals before merging
 
 Skill changes ship with eval results, produced via the `skill-creator` workflow above. Eval definitions (the prompts and their assertions) live alongside the skill at `skills/<name>/evals/evals.json` so they can be re-run against future versions. Raw run artifacts (per-eval outputs, grading JSON, the HTML viewer) belong in a workspace directory outside the repo so the commit history stays focused on the skill and its evals.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-(under development)
+# Baseten Skills
+
+Agent skills for working with [Baseten](https://www.baseten.co).
+
+## Purpose
+
+These skills teach AI coding agents how to use Baseten effectively, grounded in Baseten's own docs, Truss source, and published examples. They route the agent to the right surface for the task (Truss authoring, the truss CLI, Model APIs, the inference and management APIs) and surface the non-obvious details an agent would otherwise get wrong.
+
+## Skills
+
+- [`baseten`](skills/baseten) - deploying, configuring, calling, and operating models on Baseten. Covers Truss authoring (`config.yaml`, Python `model.py`, custom Docker servers, engine-only deploys), the `truss` CLI, Chains, environments and rolling deployments, pre-hosted Baseten Model APIs, and custom deployments via the inference and management APIs.
+
+## Install
+
+### Using the skills CLI
+
+```
+npx skills add basetenlabs/baseten-skills
+```
+
+### Manual (Claude Code)
+
+```
+git clone https://github.com/basetenlabs/baseten-skills.git
+ln -s "$(pwd)/baseten-skills/skills/baseten" ~/.claude/skills/baseten
+```
+
+Copy the directory instead of symlinking if you prefer.
+
+## Layout
+
+Each skill is a directory under `skills/` with a `SKILL.md` entry point and an optional `references/` directory. `SKILL.md` is always loaded when the skill is triggered; reference files are loaded on demand per the routing in `SKILL.md`.

--- a/eval-results/baseten/2026-04-17.md
+++ b/eval-results/baseten/2026-04-17.md
@@ -4,7 +4,7 @@ First eval pass for the `baseten` skill at `skills/baseten/`. Five prompts, each
 
 ## Prompts
 
-1. **deploy-llama-finetune**: "I need to deploy my fine-tune of Llama-3.1-8B-Instruct on Baseten. The fine-tune is on Hugging Face at acme/llama-3.1-8b-ft (private repo, I have access via the HF_ACCESS_TOKEN secret in my Baseten workspace). I want it on an L4 GPU with 4 vCPU and 16Gi memory. Generate the files I need (config.yaml and any model code) and tell me how to deploy it."
+1. **deploy-qwen-finetune**: "I need to deploy my fine-tune of Qwen3-8B on Baseten. The fine-tune is on Hugging Face at acme/qwen3-8b-ft (private repo, I have access via the HF_ACCESS_TOKEN secret in my Baseten workspace). I want it on an L4 GPU with 4 vCPU and 16Gi memory. Generate the files I need (config.yaml and any model code) and tell me how to deploy it." (Re-run 2026-04-20 after reviewer feedback; originally used Llama-3.1-8B-Instruct.)
 2. **deploy-vllm-server**: "Deploy mistralai/Mistral-7B-Instruct-v0.3 on Baseten using vLLM as the inference server. I do not want to write any Python model code. Give me the config.yaml and tell me how to push it."
 3. **call-deployed-model-streaming**: "Write me a Python script that calls my deployed Baseten model and streams the response token by token. The model id is abc12345 and it is deployed in production. It is OpenAI-compatible (vLLM). Use the OpenAI SDK if appropriate."
 4. **promote-deployment-to-staging**: "I want to script the following with curl: list all deployments for model id abc12345, find the most recent development deployment, then promote it to a new environment called 'staging'. Show me the exact requests."
@@ -16,7 +16,7 @@ The full set lives in `skills/baseten/evals/evals.json`.
 
 | Eval | With-skill assertions | Baseline assertions | Notes |
 |---|---|---|---|
-| 0 deploy-llama-finetune | 7 / 8 | 8 / 8 | Skill chose vLLM custom server (modern path); baseline chose Python class with `transformers` (works but slower per-token). Skill skipped `python_version` (defensible for custom server but assertion fired). |
+| 0 deploy-qwen-finetune | 8 / 8 | 8 / 8 | Skill chose vLLM custom server (modern path) with `model_cache` for fast cold starts; baseline chose Python class with `transformers` + `device_map="auto"` (works but slower per-token). Skill included `python_version` this time, closing last iteration's gap. Both passed all assertions. |
 | 1 deploy-vllm-server | 7 / 7 | 2 / 7 by strict reading; valid alternative | Skill: `docker_server` + `vllm/vllm-openai` image + `model_cache`. Baseline: `build.model_server: VLLM` (a different valid Baseten path that the skill does not currently mention). Assertions over-prescribed one of two valid paths. |
 | 2 call-deployed-model-streaming | 7 / 7 | 6 / 7 | Skill's URL knowledge mattered: with-skill used `/environments/production/sync/v1` (correct); baseline used `/production/v1` (wrong, would fail in practice). |
 | 3 promote-deployment-to-staging | 6 / 6 | 6 / 6 | Tie. Both correctly used Api-Key auth, hit the right endpoints, and prefaced with environment creation. Baseline found the `/deployments/development` shortcut, which the skill does not document. |
@@ -26,13 +26,15 @@ Per-run timing and tokens (Sonnet, foreground after the first eval):
 
 | Eval | With-skill tokens / s | Baseline tokens / s |
 |---|---|---|
-| 0 | 29.3k / 123s | 14.2k / 46s |
+| 0 | 25.8k / 83s | 14.2k / 62s |
 | 1 | 25.1k / 63s | 15.6k / 47s |
 | 2 | 18.2k / 40s | 13.0k / 23s |
 | 3 | 22.0k / 54s | 32.5k / 160s |
 | 4 | 20.6k / 71s | 19.9k / 104s |
 
 With-skill runs cost more on average (skill body + relevant references load into context). Baseline timing varied more, sometimes spending longer because the agent went exploring (eval 3 baseline took 160s spelunking the management API docs).
+
+Wall-clock durations here include any time spent waiting on interactive tool-permission approvals, which varied run to run. Token counts are trustworthy; seconds are directional, not precise. Do not over-read small deltas (including the eval-0 rerun numbers vs. the originals).
 
 ## Where the skill clearly helped
 
@@ -45,7 +47,6 @@ With-skill runs cost more on average (skill body + relevant references load into
 
 - **Eval 3** - tie. Skill content here adds little over what an agent can derive from the public management API docs.
 - **Eval 1 (baseline path)** - baseline found `build.model_server: VLLM`, a Baseten-managed shortcut the skill never mentions. The skill currently teaches `docker_server` for vLLM only. Real users may pick the simpler path; the skill should at least name it.
-- **Eval 0 (python_version)** - the skill's custom-server output omits `python_version`. Defensible (custom server uses the image's Python) but worth a one-line clarification in the custom-servers reference.
 - **Eval 3 (development shortcut)** - the management API has `/v1/models/{id}/deployments/development` which is simpler than listing + filtering. The skill does not document this; the baseline found it.
 
 ## Assertion issues to fix in iteration 2

--- a/eval-results/baseten/2026-04-17.md
+++ b/eval-results/baseten/2026-04-17.md
@@ -1,0 +1,70 @@
+# `baseten` skill - iteration 1 - 2026-04-17
+
+First eval pass for the `baseten` skill at `skills/baseten/`. Five prompts, each run twice (with-skill, baseline = no skill). All runs on Sonnet via subagent. Raw run artifacts kept in a local workspace directory outside the repo, per CONTRIBUTING.md.
+
+## Prompts
+
+1. **deploy-llama-finetune**: "I need to deploy my fine-tune of Llama-3.1-8B-Instruct on Baseten. The fine-tune is on Hugging Face at acme/llama-3.1-8b-ft (private repo, I have access via the HF_ACCESS_TOKEN secret in my Baseten workspace). I want it on an L4 GPU with 4 vCPU and 16Gi memory. Generate the files I need (config.yaml and any model code) and tell me how to deploy it."
+2. **deploy-vllm-server**: "Deploy mistralai/Mistral-7B-Instruct-v0.3 on Baseten using vLLM as the inference server. I do not want to write any Python model code. Give me the config.yaml and tell me how to push it."
+3. **call-deployed-model-streaming**: "Write me a Python script that calls my deployed Baseten model and streams the response token by token. The model id is abc12345 and it is deployed in production. It is OpenAI-compatible (vLLM). Use the OpenAI SDK if appropriate."
+4. **promote-deployment-to-staging**: "I want to script the following with curl: list all deployments for model id abc12345, find the most recent development deployment, then promote it to a new environment called 'staging'. Show me the exact requests."
+5. **long-running-async-inference**: "I want to run a 20-minute generation against my deployed Baseten model (id abc12345, production). I do not want to keep an HTTP connection open for that long. What is the right way to do this on Baseten? Show me code."
+
+The full set lives in `skills/baseten/evals/evals.json`.
+
+## Results summary
+
+| Eval | With-skill assertions | Baseline assertions | Notes |
+|---|---|---|---|
+| 0 deploy-llama-finetune | 7 / 8 | 8 / 8 | Skill chose vLLM custom server (modern path); baseline chose Python class with `transformers` (works but slower per-token). Skill skipped `python_version` (defensible for custom server but assertion fired). |
+| 1 deploy-vllm-server | 7 / 7 | 2 / 7 by strict reading; valid alternative | Skill: `docker_server` + `vllm/vllm-openai` image + `model_cache`. Baseline: `build.model_server: VLLM` (a different valid Baseten path that the skill does not currently mention). Assertions over-prescribed one of two valid paths. |
+| 2 call-deployed-model-streaming | 7 / 7 | 6 / 7 | Skill's URL knowledge mattered: with-skill used `/environments/production/sync/v1` (correct); baseline used `/production/v1` (wrong, would fail in practice). |
+| 3 promote-deployment-to-staging | 6 / 6 | 6 / 6 | Tie. Both correctly used Api-Key auth, hit the right endpoints, and prefaced with environment creation. Baseline found the `/deployments/development` shortcut, which the skill does not document. |
+| 4 long-running-async-inference | 6 / 6 | ~5 / 6 | Both reached for `async_predict` + webhook. Baseline submit script does not explicitly mention "outputs not stored, persist before 200" the way with-skill does (the with-skill `response.md` calls it out). |
+
+Per-run timing and tokens (Sonnet, foreground after the first eval):
+
+| Eval | With-skill tokens / s | Baseline tokens / s |
+|---|---|---|
+| 0 | 29.3k / 123s | 14.2k / 46s |
+| 1 | 25.1k / 63s | 15.6k / 47s |
+| 2 | 18.2k / 40s | 13.0k / 23s |
+| 3 | 22.0k / 54s | 32.5k / 160s |
+| 4 | 20.6k / 71s | 19.9k / 104s |
+
+With-skill runs cost more on average (skill body + relevant references load into context). Baseline timing varied more, sometimes spending longer because the agent went exploring (eval 3 baseline took 160s spelunking the management API docs).
+
+## Where the skill clearly helped
+
+- **Eval 2** - correct OpenAI-SDK base URL. The `/environments/production/sync/v1` path is non-obvious and the baseline got it wrong. This alone justifies the skill for any user calling deployed vLLM models.
+- **Eval 0** - steering toward vLLM custom server over hand-rolled `transformers` + `pipeline`. Modern serving choice.
+- **Eval 0 / Eval 1** - `model_cache` recipe for fast cold starts. Skill-derived; baseline (eval 0) did not include it.
+- **Eval 4** - explicit "Baseten does not store outputs, persist before returning 200" call-out. Baseline implicitly did the right thing but did not raise the durability concern.
+
+## Where the skill did not help (or hurt)
+
+- **Eval 3** - tie. Skill content here adds little over what an agent can derive from the public management API docs.
+- **Eval 1 (baseline path)** - baseline found `build.model_server: VLLM`, a Baseten-managed shortcut the skill never mentions. The skill currently teaches `docker_server` for vLLM only. Real users may pick the simpler path; the skill should at least name it.
+- **Eval 0 (python_version)** - the skill's custom-server output omits `python_version`. Defensible (custom server uses the image's Python) but worth a one-line clarification in the custom-servers reference.
+- **Eval 3 (development shortcut)** - the management API has `/v1/models/{id}/deployments/development` which is simpler than listing + filtering. The skill does not document this; the baseline found it.
+
+## Assertion issues to fix in iteration 2
+
+- **Eval 0**: `python_version` assertion should not fire when the deployment uses a `docker_server` block (the image owns the Python).
+- **Eval 1**: assertions assume the `docker_server` path. They should accept either `docker_server` with a vLLM image *or* `build.model_server: VLLM` as valid vLLM deployments.
+
+## Takeaways for the skill (iteration 2 candidate changes)
+
+1. In `truss-config.md` (or a new section in `truss-custom-servers.md`), add `build.model_server: VLLM` (and `SGLang`, etc., if applicable) as a third "managed engine via build" path alongside `docker_server` and engine-only blocks. Link to docs for the full set.
+2. In `truss-custom-servers.md`, note that `python_version` is unused when `base_image` overrides the runtime - so its absence is correct, not a bug.
+3. In `management-api.md`, mention the `/v1/models/{id}/deployments/development` and `/production` direct-access endpoints alongside the list-and-filter pattern.
+4. Consider whether the skill should ever recommend `build.model_server: VLLM` over `docker_server` for plain LLM serving. It is shorter and Baseten-managed; the docker_server path gives more control. A "which to pick" line would help.
+
+No code changes made yet - this writeup is the input to iteration 2.
+
+## Caveats
+
+- Subagents were instructed not to read locally cloned `baseten-truss/`, `docs.baseten.co/`, `truss-examples/`, or `baseten/` repos to keep the eval fair.
+- WebFetch to public docs was permitted on a per-run basis as the user approved prompts. Confirmed: eval 3 baseline was approved for docs queries; eval 4 baseline was not. With-skill runs likely did not need to fetch docs (the skill is on disk) but this was not strictly verified.
+- Eval 0 baseline was originally launched in parallel with eval-0 with-skill in background mode and hit a permission denial on Write; re-run in foreground after settings were updated. The eval-0 baseline timing above is for the foreground re-run.
+- The first eval-2 with-skill run was a single-subagent smoke test used to verify the permissions/sandbox change worked. Its output was kept as the with-skill artifact.

--- a/skills/baseten/SKILL.md
+++ b/skills/baseten/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: baseten
+description: Use this skill for anything involving Baseten or Truss, such as deploying a custom model, writing or debugging a `config.yaml`, choosing between a Python `model.py`, a custom Docker server (vLLM/TGI/SGLang/Triton), or an engine-only deploy (TensorRT-LLM, BEI, BIS-LLM), running `truss push` or `truss watch`, working with Chains, managing environments and rolling deployments, calling pre-hosted Baseten Model APIs, or calling custom deployments via the inference API or managing them via the management API.
+---
+
+# Baseten
+
+Baseten is a platform for serving machine learning models. Two broad paths exist:
+
+- **Model APIs** - pre-hosted, ready-to-call models (chat, embeddings, etc.) accessed over HTTP. No deployment step. Good when a hosted model already does what the user needs.
+- **Custom deployments via Truss** - package and deploy a user-supplied model. A Truss is a directory containing a `config.yaml` plus optionally model code, a custom server image, or an engine config. Built and deployed with the `truss` CLI; operated via the management API; called via the inference API.
+
+This skill is the entry point for any Baseten work. Read this body fully, then load only the references relevant to the task.
+
+## Mental model for custom deployments
+
+A deployed Truss has three pieces a user works with:
+
+1. **The Truss** (source): a directory you author.
+2. **The deployment** (running): a containerized instance attached to an environment such as `development` or `production`.
+3. **The endpoint** (call site): the URL clients hit, e.g. `https://model-{id}.api.baseten.co/environments/production/predict`.
+
+Almost every custom-deployment task touches one or more.
+
+## Three ways to author a Truss
+
+Pick the simplest one that fits.
+
+| Flavor | When to pick | Reference |
+|---|---|---|
+| **Python class** (`model.py` with `load`/`predict`) | Custom pre/post-processing, custom architectures, anything needing Python in the request path. | `references/truss-model-py.md` |
+| **Custom server** (`docker_server` block, BYO HTTP server such as vLLM, TGI, SGLang, Triton) | An existing inference server already does the job. Often the most popular path for modern LLMs. | `references/truss-custom-servers.md` |
+| **Engine-only** (no code; engine config in `config.yaml`, e.g. TensorRT-LLM, BEI, BIS-LLM) | Standard architecture covered by a Baseten-supported engine. Fastest path; no Python or Docker to maintain. | `references/truss-config.md` (engines section) |
+
+If unsure which flavor fits, ask. Don't default to Python class out of habit; custom servers and engines are often better choices.
+
+## Decision routing
+
+Match the task to the reference(s) to load. **Only load what you need.**
+
+| Task | Load |
+|---|---|
+| Calling a pre-hosted Model API | `references/model-apis.md` |
+| Writing or editing `config.yaml` | `references/truss-config.md` |
+| Writing the Python `Model` class | `references/truss-model-py.md` |
+| Configuring a custom Docker server | `references/truss-custom-servers.md` |
+| Running `truss push`, `truss watch`, `truss init` | `references/truss-cli.md` |
+| Building a multi-step inference pipeline | `references/truss-chains.md` |
+| Understanding environments, promotion, rolling deploys, autoscaling | `references/deployment-lifecycle.md` |
+| Listing/promoting/deleting deployments programmatically | `references/management-api.md` |
+| Calling a custom-deployed model (sync, streaming, async, OpenAI-compat) | `references/inference-api.md` |
+
+## Installing the truss CLI
+
+Preferred:
+
+```
+uv tool install truss     # installs the CLI as a uv-managed tool
+# or
+uvx truss <command>       # run without installing
+```
+
+`pip install truss` also works in a regular Python environment. Authentication and first-push setup are covered in `references/truss-cli.md`.
+
+## Getting started (custom deployment)
+
+End-to-end shape of a first Truss deployment. Each step has a deeper reference.
+
+1. **Scaffold**: `truss init my-model` creates a directory with a starter `config.yaml` and `model.py`. See `references/truss-cli.md`.
+2. **Choose a flavor** and edit accordingly: keep the generated `model.py` (Python class), replace it with a `docker_server` block (custom server), or use an engine block (engine-only). See the three-flavors table above.
+3. **Edit `config.yaml`**: set `model_name`, `python_version`, `resources`, `requirements`, and any secrets. See `references/truss-config.md`.
+4. **Push**: `truss push` for a published deployment, or `truss push --watch` for an iterative development deployment that live-reloads. See `references/truss-cli.md`.
+5. **Call**: hit the model's inference endpoint (use curl, `requests`, the OpenAI SDK pointed at a Baseten base URL, etc.). See `references/inference-api.md`.
+
+### Minimal Python Truss example
+
+A complete Python-class Truss is just two files. This example deploys [Phi-3-mini-4k-instruct](https://huggingface.co/microsoft/Phi-3-mini-4k-instruct) on a T4 GPU; it is the published walkthrough at <https://docs.baseten.co/examples/customize-a-model>.
+
+`model/model.py`:
+
+```python
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+class Model:
+    def __init__(self, **kwargs):
+        self._model = None
+        self._tokenizer = None
+
+    def load(self):
+        self._model = AutoModelForCausalLM.from_pretrained(
+            "microsoft/Phi-3-mini-4k-instruct",
+            device_map="cuda",
+            torch_dtype="auto",
+        )
+        self._tokenizer = AutoTokenizer.from_pretrained(
+            "microsoft/Phi-3-mini-4k-instruct"
+        )
+
+    def predict(self, request):
+        messages = request.pop("messages")
+        model_inputs = self._tokenizer.apply_chat_template(
+            messages, tokenize=False, add_generation_prompt=True
+        )
+        inputs = self._tokenizer(model_inputs, return_tensors="pt").to("cuda")
+        with torch.no_grad():
+            outputs = self._model.generate(input_ids=inputs["input_ids"], max_length=256)
+        return {"output": self._tokenizer.decode(outputs[0], skip_special_tokens=True)}
+```
+
+`config.yaml`:
+
+```yaml
+python_version: py311
+requirements:
+  - six==1.17.0
+  - accelerate==0.30.1
+  - einops==0.8.0
+  - transformers==4.41.2
+  - torch==2.3.0
+resources:
+  accelerator: T4
+  use_gpu: true
+```
+
+Deploy and call: `uvx truss push --watch`, then POST to `https://model-{id}.api.baseten.co/development/predict` with an `Authorization: Api-Key $BASETEN_API_KEY` header.
+
+## Out of scope for this skill
+
+- **Advanced Python authoring patterns** (sophisticated streaming, custom batching, performance tuning of the in-process Python server, fine-grained Truss internals). May be covered by a future, more specialized skill. For now, stick to the contract documented in `references/truss-model-py.md` and refer the user to `docs.baseten.co` for deeper material.
+- **Model training on Baseten** (Truss-Train). Out of scope here; mention that a separate path exists if asked.
+- **Web UI navigation.** Defer to docs.baseten.co.
+- Generic Docker / FastAPI / vLLM questions where the user is not deploying to Baseten.
+
+## External resources
+
+When references in this skill don't cover something, consult these before guessing. Per-resource references (e.g. for OpenAPI specs, config schema) live in the relevant reference files.
+
+- **Baseten docs**: <https://docs.baseten.co> - authoritative for product behavior.
+- **Truss source and issues**: <https://github.com/basetenlabs/truss>.
+- **Truss examples**: <https://github.com/basetenlabs/truss-examples> - real `config.yaml` and `model.py` files for many model families.

--- a/skills/baseten/evals/evals.json
+++ b/skills/baseten/evals/evals.json
@@ -1,0 +1,153 @@
+{
+  "skill_name": "baseten",
+  "evals": [
+    {
+      "id": 0,
+      "name": "deploy-llama-finetune",
+      "prompt": "I need to deploy my fine-tune of Llama-3.1-8B-Instruct on Baseten. The fine-tune is on Hugging Face at acme/llama-3.1-8b-ft (private repo, I have access via the HF_ACCESS_TOKEN secret in my Baseten workspace). I want it on an L4 GPU with 4 vCPU and 16Gi memory. Generate the files I need (config.yaml and any model code) and tell me how to deploy it.",
+      "expected_output": "A working Truss directory: a config.yaml referencing the L4, declaring the hf_access_token secret by name (not value), pinning python_version, and either a model.py loading the model from HF or a custom_server / engine config that does the same. Deploy command should mention truss push (with appropriate flags).",
+      "files": [],
+      "assertions": [
+        {
+          "text": "A config.yaml file is produced",
+          "check": "file_exists"
+        },
+        {
+          "text": "config.yaml selects an L4 GPU (accelerator: L4 or instance_type starts with L4:)"
+        },
+        {
+          "text": "config.yaml requests 4 vCPU and 16Gi memory (or instance_type L4:4x16)"
+        },
+        {
+          "text": "config.yaml declares the hf_access_token secret by name without a real token value"
+        },
+        {
+          "text": "No real Hugging Face token (hf_...) appears in any output file"
+        },
+        {
+          "text": "Output includes either a model.py with load/predict, a docker_server block, or an engine block (not all three)"
+        },
+        {
+          "text": "config.yaml sets python_version (e.g. py311)"
+        },
+        {
+          "text": "Recommended deploy command is some form of `truss push`"
+        }
+      ]
+    },
+    {
+      "id": 1,
+      "name": "deploy-vllm-server",
+      "prompt": "Deploy mistralai/Mistral-7B-Instruct-v0.3 on Baseten using vLLM as the inference server. I do not want to write any Python model code. Give me the config.yaml and tell me how to push it.",
+      "expected_output": "A custom-server config.yaml with a docker_server block (start_command launching vLLM, OpenAI-compatible endpoints), no model.py, server_port not 8080, base_image set to a vLLM image, resources with a GPU appropriate for Mistral 7B.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "A config.yaml is produced and no model.py is written"
+        },
+        {
+          "text": "config.yaml contains a docker_server block"
+        },
+        {
+          "text": "docker_server.server_port is not 8080"
+        },
+        {
+          "text": "docker_server has predict_endpoint, readiness_endpoint, and liveness_endpoint set"
+        },
+        {
+          "text": "base_image points at a vLLM-capable image (e.g. vllm/vllm-openai)"
+        },
+        {
+          "text": "start_command launches vLLM serving Mistral-7B-Instruct-v0.3"
+        },
+        {
+          "text": "resources block includes a GPU appropriate for a 7B model (L4/A10G/A100 or larger)"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "call-deployed-model-streaming",
+      "prompt": "Write me a Python script that calls my deployed Baseten model and streams the response token by token. The model id is abc12345 and it is deployed in production. It is OpenAI-compatible (vLLM). Use the OpenAI SDK if appropriate.",
+      "expected_output": "Python that uses the OpenAI SDK with base_url pointed at https://model-abc12345.api.baseten.co/environments/production/sync/v1 (or equivalent sync path), api_key from BASETEN_API_KEY env var, stream=True in the chat.completions.create call, and a loop printing chunk.choices[0].delta.content.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "A Python script is produced (.py file)"
+        },
+        {
+          "text": "Script imports the openai package"
+        },
+        {
+          "text": "OpenAI client base_url contains model-abc12345.api.baseten.co"
+        },
+        {
+          "text": "Base URL uses the /sync/v1 path (or equivalent OpenAI-compat sync route)"
+        },
+        {
+          "text": "api_key is sourced from the BASETEN_API_KEY environment variable, not hardcoded"
+        },
+        {
+          "text": "chat.completions.create is called with stream=True"
+        },
+        {
+          "text": "Script iterates streamed chunks and prints chunk.choices[0].delta.content (or equivalent)"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "name": "promote-deployment-to-staging",
+      "prompt": "I want to script the following with curl: list all deployments for model id abc12345, find the most recent development deployment, then promote it to a new environment called 'staging'. Show me the exact requests.",
+      "expected_output": "Bash/curl commands hitting the Baseten management API at https://api.baseten.co/v1/... with Authorization: Api-Key $BASETEN_API_KEY header. Should reference /v1/models/{id}/deployments to list, /v1/models/{id}/environments POST to create staging, and /v1/models/{id}/environments/staging/promote to promote.",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Output uses HTTP requests to https://api.baseten.co/v1/..."
+        },
+        {
+          "text": "Authorization header uses the `Api-Key` prefix, not `Bearer`"
+        },
+        {
+          "text": "Lists deployments via GET /v1/models/abc12345/deployments"
+        },
+        {
+          "text": "Creates the staging environment via POST /v1/models/abc12345/environments"
+        },
+        {
+          "text": "Promotes via POST /v1/models/abc12345/environments/staging/promote"
+        },
+        {
+          "text": "API key is read from an env var (e.g. $BASETEN_API_KEY), not hardcoded"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "name": "long-running-async-inference",
+      "prompt": "I want to run a 20-minute generation against my deployed Baseten model (id abc12345, production). I do not want to keep an HTTP connection open for that long. What is the right way to do this on Baseten? Show me code.",
+      "expected_output": "Should use async_predict at https://model-abc12345.api.baseten.co/environments/production/async_predict, include a webhook_endpoint URL, return a request_id, and either show a webhook receiver or poll /async_request/{request_id}. Should not attempt streaming (which is incompatible with async).",
+      "files": [],
+      "assertions": [
+        {
+          "text": "Recommends the async_predict pattern (not sync /predict)"
+        },
+        {
+          "text": "URL contains /async_predict"
+        },
+        {
+          "text": "Request payload includes a webhook_endpoint field"
+        },
+        {
+          "text": "Auth uses the `Api-Key` prefix, not `Bearer`"
+        },
+        {
+          "text": "Notes that Baseten does not store outputs (so webhook receiver must persist) OR mentions polling /async_request/{id}"
+        },
+        {
+          "text": "Does not attempt to combine async with streaming"
+        }
+      ]
+    }
+  ]
+}

--- a/skills/baseten/evals/evals.json
+++ b/skills/baseten/evals/evals.json
@@ -3,8 +3,8 @@
   "evals": [
     {
       "id": 0,
-      "name": "deploy-llama-finetune",
-      "prompt": "I need to deploy my fine-tune of Llama-3.1-8B-Instruct on Baseten. The fine-tune is on Hugging Face at acme/llama-3.1-8b-ft (private repo, I have access via the HF_ACCESS_TOKEN secret in my Baseten workspace). I want it on an L4 GPU with 4 vCPU and 16Gi memory. Generate the files I need (config.yaml and any model code) and tell me how to deploy it.",
+      "name": "deploy-qwen-finetune",
+      "prompt": "I need to deploy my fine-tune of Qwen3-8B on Baseten. The fine-tune is on Hugging Face at acme/qwen3-8b-ft (private repo, I have access via the HF_ACCESS_TOKEN secret in my Baseten workspace). I want it on an L4 GPU with 4 vCPU and 16Gi memory. Generate the files I need (config.yaml and any model code) and tell me how to deploy it.",
       "expected_output": "A working Truss directory: a config.yaml referencing the L4, declaring the hf_access_token secret by name (not value), pinning python_version, and either a model.py loading the model from HF or a custom_server / engine config that does the same. Deploy command should mention truss push (with appropriate flags).",
       "files": [],
       "assertions": [

--- a/skills/baseten/references/deployment-lifecycle.md
+++ b/skills/baseten/references/deployment-lifecycle.md
@@ -1,0 +1,147 @@
+# Deployment lifecycle
+
+How a deployed model moves from first push to production, how traffic and autoscaling work, and what the platform gives you for safe rollouts. This is platform-level information that applies to any Truss deployed on Baseten (Python-class, custom server, or engine-only).
+
+Authoritative docs live under <https://docs.baseten.co/deployment/>. This file summarizes the shape and flags what matters most.
+
+## The hierarchy
+
+- **Model**: the top-level entity in a workspace. Has a stable model ID.
+- **Deployment**: a containerized instance of a model serving HTTP. Has its own deployment ID. A model can have many deployments simultaneously.
+- **Environment**: a named slot (e.g. `production`, `staging`) that a deployment can be promoted into. The environment owns the autoscaling settings and the stable endpoint URL.
+
+Every deployment has a REST endpoint automatically. Environment-attached deployments also get a stable URL under `/environments/{name}/predict`.
+
+## Development vs published deployments
+
+A **development deployment** is a mutable slot meant for iteration:
+
+- Created with `truss push --watch` (or `truss chains push --watch`).
+- Single replica, scales to zero when idle.
+- Live reload via `truss watch` patches code in place.
+- No autoscaling; no zero-downtime updates.
+- Can be promoted later.
+
+A **published deployment** is immutable:
+
+- Created with plain `truss push` (or with `--promote` / `--environment`).
+- Has autoscaling.
+- Can be promoted to environments and rolled out safely.
+- Is the right target for any non-exploratory work.
+
+## Environments
+
+Environments provide logical isolation and stable endpoints for a deployment lifecycle (dev, staging, production, etc.).
+
+- `production` exists by default, cannot be deleted unless the entire model is removed, and its name is reserved (no other environment can be called `production`).
+- Create custom environments from the dashboard or via the management API (<https://docs.baseten.co/reference/management-api/environments/create-an-environment>).
+- Deployments do not have to be in an environment to be callable. Environments add autoscaling control, stable routing, and rollout features on top.
+
+### Environment in `model.py`
+
+`Model.__init__` can accept an `environment` keyword argument; Truss injects the current environment context there. Use it to drive per-environment behavior in `load`:
+
+```python
+def __init__(self, **kwargs):
+    self._environment = kwargs["environment"]
+
+def load(self):
+    if self._environment and self._environment.get("name") == "production":
+        ...
+```
+
+If you do this, enable **Re-deploy when promoting** on the environment (dashboard or management API) so `load()` actually re-runs when the deployment moves into a new environment. Otherwise the original `load` state is reused.
+
+## Promotion
+
+Promoting a deployment attaches it to an environment. Three ways to do it:
+
+- `truss push --promote` - publish and promote straight to production in one step.
+- `truss push --environment <name>` - publish and promote into a named environment.
+- Dashboard or management API - promote an existing deployment after the fact.
+
+Semantics:
+
+- If the source deployment can be reused, promotion is an in-place attachment and is fast.
+- A new deployment is created when: the source is already attached to another environment, the target environment has a different instance type or resource profile, or the environment has "Re-deploy on promotion" enabled.
+- On promotion, the new deployment inherits the previous environment deployment's autoscaling settings; the previous deployment is demoted (but kept).
+- Only one active promotion per environment at a time.
+
+## Rolling deployments
+
+When promoting a published deployment into an environment that already has one, the rollout can be **rolling**: scale up the candidate, shift traffic proportionally, scale down the previous. Pause / resume / cancel / force-complete are available.
+
+Details: <https://docs.baseten.co/deployment/rolling-deployments>.
+
+Key points:
+
+- Autoscaling is **suspended during a rolling deployment** for the whole environment. Use `replica_overhead_percent` to pre-provision capacity if traffic is expected to grow mid-rollout.
+- Rolling deployments are **not supported for Chains**.
+- "Canary deployments" are deprecated in favor of rolling deployments.
+
+## Autoscaling
+
+Each environment's autoscaling controls independently:
+
+- `min_replicas` (default 0 enables scale-to-zero).
+- `max_replicas`.
+- `concurrency_target` per replica.
+- `autoscaling_window` (smoothing period).
+- `scale_down_delay` (how long to wait before reducing replicas).
+
+Set per environment from the dashboard or the management API (<https://docs.baseten.co/reference/management-api/deployments/autoscaling/updates-a-deployments-autoscaling-settings>).
+
+Full concept docs: <https://docs.baseten.co/deployment/autoscaling/overview>.
+
+## Regional environments
+
+Regional environments restrict inference traffic to a specific geographic region for data residency compliance. When enabled for the organization, each environment gets a dedicated regional endpoint whose hostname embeds the environment name:
+
+```
+https://model-{id}-{env}.api.baseten.co/predict
+```
+
+Path-based environment selection (`/environments/{name}/predict`, `/production/predict`, `/deployment/{id}/predict`) is rejected on regional endpoints. Contact the Baseten account team to enable. Full details: <https://docs.baseten.co/deployment/regional-environments>.
+
+## Managing deployments
+
+- **Naming**: custom deployment names via `truss push --deployment-name <name>` or the dashboard. Names are cosmetic; APIs still address by ID.
+- **Deactivating**: suspends serving while preserving config. No compute cost; inference returns 404. Reactivate anytime.
+- **Deleting**: permanent. Production deployments must be replaced before deletion.
+
+Programmatic equivalents live in `management-api.md` in this skill.
+
+## CI/CD
+
+The normal CI/CD shape is `truss push` with some mix of `--wait`, `--tail`, `--json`, `--environment`, `--include-git-info`, and `--labels`. See `truss-cli.md` for specifics. <https://docs.baseten.co/deployment/ci-cd> has worked examples.
+
+## Logs and observability
+
+Per-deployment logs are available in the dashboard under each deployment. The CLI can also tail them:
+
+- `truss push --tail` during a push.
+- `truss watch` during development.
+- `truss model-logs <model-id>` for a one-shot fetch.
+
+Per-request log correlation uses the `X-Baseten-Request-Id` header returned on every response. Standard Python Trusses log this automatically; custom servers must format JSON logs with a top-level `request_id` field (see `truss-custom-servers.md`).
+
+Broader observability (metrics export, alerting, tracing): <https://docs.baseten.co/observability>.
+
+## Gotchas
+
+- **Rolling deployments suspend autoscaling** for the environment for their whole duration. If replicas look wrong during a rollout, this is why.
+- **`production` is reserved** and cannot be deleted without deleting the model.
+- **Development deployments scale to zero** (unless a `truss watch` is active, which keeps them warm). Published deployments do not scale to zero unless autoscaling is configured that way.
+- **Promotion may or may not create a new deployment.** If you need `load()` to re-run on promotion, enable "Re-deploy when promoting" on the environment.
+- **Chains cannot use rolling deployments.** Promotions for Chains are immediate traffic swaps.
+- **Only one active promotion per environment at a time.** Queue or wait if another rollout is in flight.
+
+## Further reading
+
+- Deployments: <https://docs.baseten.co/deployment/deployments>
+- Environments: <https://docs.baseten.co/deployment/environments>
+- Rolling deployments: <https://docs.baseten.co/deployment/rolling-deployments>
+- Autoscaling: <https://docs.baseten.co/deployment/autoscaling/overview>
+- Regional environments: <https://docs.baseten.co/deployment/regional-environments>
+- CI/CD: <https://docs.baseten.co/deployment/ci-cd>
+- Programmatic control: `management-api.md` in this skill.

--- a/skills/baseten/references/inference-api.md
+++ b/skills/baseten/references/inference-api.md
@@ -1,0 +1,192 @@
+# Baseten inference API
+
+Calling deployed models and Chains over HTTPS. Pre-hosted Model APIs (the OpenAI-compatible catalog of managed LLMs like DeepSeek, GLM, Kimi) live on a separate endpoint and are covered in `model-apis.md`. This file covers **custom deployments**: models and chains the user packaged with Truss and deployed to their workspace.
+
+- OpenAPI spec (authoritative): <https://api.baseten.co/inference-spec>
+- Reference overview: <https://docs.baseten.co/reference/inference-api/overview>
+
+## Authentication
+
+Every request sends an `Authorization: Api-Key $BASETEN_API_KEY` header. API keys are created at <https://app.baseten.co/settings/account/api_keys>.
+
+## Endpoint URL shape
+
+**Models:**
+
+```
+https://model-{model_id}.api.baseten.co/{target}/{endpoint}
+```
+
+**Chains:**
+
+```
+https://chain-{chain_id}.api.baseten.co/{target}/{endpoint}
+```
+
+`{target}` is one of:
+
+- `production` - the model's production environment.
+- `environments/{env_name}` - a named environment.
+- `development` - the development deployment.
+- `deployment/{deployment_id}` - a specific deployment by ID.
+
+`{endpoint}` is the action: `predict`, `async_predict`, `wake`, `async_queue_status`, or (for custom servers) `sync/{route}`. Chains use `run_remote` and `async_run_remote` in place of `predict` / `async_predict`.
+
+### Models: predict endpoints
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /production/predict` | Call production. |
+| `POST /environments/{env_name}/predict` | Call a named environment. |
+| `POST /development/predict` | Call the development deployment. |
+| `POST /deployment/{deployment_id}/predict` | Call a specific deployment. |
+
+`async_predict` variants exist at the same paths. See below for async semantics.
+
+### Chains: run_remote endpoints
+
+Same paths with `run_remote` / `async_run_remote` in place of `predict` / `async_predict`.
+
+### Regional endpoints
+
+When regional environments are enabled for the organization, the environment name moves into the hostname and paths become bare:
+
+```
+https://model-{model_id}-{env_name}.api.baseten.co/predict
+https://chain-{chain_id}-{env_name}.api.baseten.co/run_remote
+```
+
+Path-based environment selection is rejected on regional hostnames.
+
+## Synchronous `predict`
+
+Minimal Python example (Python-class Truss):
+
+```python
+import os
+import requests
+
+model_id = os.environ["MODEL_ID"]
+api_key = os.environ["BASETEN_API_KEY"]
+
+response = requests.post(
+    f"https://model-{model_id}.api.baseten.co/environments/production/predict",
+    headers={"Authorization": f"Api-Key {api_key}"},
+    json={"messages": [{"role": "user", "content": "Hello"}]},
+    timeout=60,
+)
+response.raise_for_status()
+print(response.json())
+```
+
+The JSON body is forwarded directly to the model's `predict` function, or to a custom server's `predict_endpoint`, or to the chain entrypoint's `run_remote`.
+
+## Streaming
+
+If the deployed model's `predict` returns a generator (or a custom server emits chunked responses), the response is an HTTP stream. Read it incrementally:
+
+```python
+with requests.post(url, headers=headers, json=payload, stream=True, timeout=60) as response:
+    response.raise_for_status()
+    for chunk in response.iter_content(chunk_size=None):
+        print(chunk.decode(), end="")
+```
+
+For OpenAI-style Server-Sent Events, use the OpenAI SDK (below) or an SSE parser. Full details: <https://docs.baseten.co/inference/streaming>.
+
+## OpenAI SDK (engine-only and OpenAI-compatible servers)
+
+Engine-only deploys (Engine-Builder-LLM, BIS-LLM) and OpenAI-compatible custom servers (vLLM, SGLang, etc. when configured that way) expose OpenAI-shaped routes. Point the OpenAI SDK at the model's **sync** path:
+
+```python
+import os
+from openai import OpenAI
+
+model_id = os.environ["MODEL_ID"]
+client = OpenAI(
+    base_url=f"https://model-{model_id}.api.baseten.co/environments/production/sync/v1",
+    api_key=os.environ["BASETEN_API_KEY"],
+)
+
+response = client.chat.completions.create(
+    model="baseten",
+    messages=[{"role": "user", "content": "Hello"}],
+    stream=True,
+)
+for chunk in response:
+    delta = chunk.choices[0].delta.content
+    if delta:
+        print(delta, end="")
+```
+
+The `model=` argument in the SDK is a placeholder (`"baseten"` is idiomatic); the actual model is the one deployed at that URL.
+
+## Sync endpoint (custom servers)
+
+Custom-server Trusses can expose any route their server implements via the `sync` path:
+
+```
+https://model-{model_id}.api.baseten.co/environments/production/sync/{route}
+```
+
+Example mappings:
+
+- `/sync/health` hits the server's `/health` route.
+- `/sync/v1/models` hits `/v1/models` (used alongside `/sync/v1/chat/completions` for full OpenAI-compat).
+
+See `truss-custom-servers.md` for how `predict_endpoint` interacts with `sync` routing.
+
+## Async inference
+
+Async is a fire-and-forget pattern: submit a request, get a `request_id` back immediately, receive the result at a webhook later. Use for long-running work or batch processing.
+
+```
+POST /production/async_predict
+{
+  "model_input": { ... },
+  "webhook_endpoint": "https://your-app.example.com/baseten-callback",
+  "max_time_in_queue_seconds": 600
+}
+```
+
+Key properties:
+
+- `max_time_in_queue_seconds` controls queue timeout; maximums move over time, so confirm current limits in the docs.
+- **Async is not compatible with streaming output.**
+- **Baseten does not store model outputs.** If webhook delivery fails after all retries, the result is lost. Design your webhook to be idempotent and, if durability matters, have it persist the payload before returning 200. See <https://docs.baseten.co/inference/async#webhook-delivery> for current retry behavior.
+- The webhook POST includes `X-BASETEN-REQUEST-ID` and a signature header. Verify signatures; see <https://docs.baseten.co/inference/async#webhook-delivery>.
+- Priority queuing is supported via a `priority` field (lower numbers take precedence); consult the async docs for the current priority scale.
+- For Chains, use `async_run_remote`. Chainlet-to-Chainlet calls stay synchronous; only the entrypoint is queued.
+
+Full docs: <https://docs.baseten.co/inference/async>.
+
+### Status and cancellation
+
+| Endpoint | Purpose |
+|---|---|
+| `GET /async_request/{request_id}` | Get current status. Available for ~1 hour after completion. |
+| `DELETE /async_request/{request_id}` | Cancel a queued async request. |
+| `GET {target}/async_queue_status` | Queue metrics for a deployment target. |
+
+## Wake endpoints
+
+If a deployment is scaled to zero, `POST {target}/wake` triggers a warm-up without sending an inference request. Useful for pre-warming right before a latency-sensitive workload.
+
+## Gotchas
+
+- **URL structure matters.** `/environments/production/predict` is different from `/production/predict`. Both hit production, but the former names the environment explicitly; the latter is the shorthand. Regional endpoints accept neither and require the bare-path form.
+- **The `model=` field in the OpenAI SDK is a placeholder.** The actual model is determined by the base URL. Setting it to something descriptive is fine; setting it to the name of an unrelated model does not change routing.
+- **Async never streams.** If the user needs both (long job with incremental output), this is a design constraint, not a client bug.
+- **Failed webhook delivery after retries loses the result.** Log and persist on the webhook side before returning 200.
+- **Request timeouts are on your client.** Long `predict` calls need a client timeout large enough (or use async).
+- **Gates on `development` targets return 404 when the dev deployment has scaled to zero** between requests. `truss watch` keeps it warm; outside of `watch`, consider `/wake` or the scale-to-zero behavior.
+- **Custom server `sync` routing only works for routes the server actually exposes.** `predict_endpoint` is the shortcut for the primary inference route; everything else uses `/sync/{route}`.
+
+## Further reading
+
+- Calling deployed models: <https://docs.baseten.co/inference/calling-your-model>
+- Inference API overview: <https://docs.baseten.co/reference/inference-api/overview>
+- Streaming: <https://docs.baseten.co/inference/streaming>
+- Async and webhooks: <https://docs.baseten.co/inference/async>
+- OpenAPI spec: <https://api.baseten.co/inference-spec>
+- Pre-hosted Model APIs: `model-apis.md` in this skill.

--- a/skills/baseten/references/management-api.md
+++ b/skills/baseten/references/management-api.md
@@ -1,0 +1,153 @@
+# Baseten management API
+
+The management API is the programmatic control plane for models, deployments, environments, autoscaling, secrets, API keys, teams, and billing. Use it from scripts and CI when the truss CLI or the dashboard do not fit the workflow. The `truss` CLI itself uses this API under the hood for push and promotion operations.
+
+- Base URL: `https://api.baseten.co`
+- OpenAPI spec (authoritative): <https://api.baseten.co/v1/spec>
+- Reference docs (grouped by resource): <https://docs.baseten.co/reference/management-api/overview>
+
+Prefer generating a client from the OpenAPI spec for non-trivial integrations rather than hand-rolling HTTP calls.
+
+## Authentication
+
+Every request needs an API key in the `Authorization` header:
+
+```
+Authorization: Api-Key $BASETEN_API_KEY
+```
+
+API keys are created at <https://app.baseten.co/settings/account/api_keys> (user keys) or programmatically via the API Key endpoints.
+
+## Resource shape at a glance
+
+All paths are under `/v1`. The surface divides cleanly:
+
+- **Models**: `/v1/models`, `/v1/models/{model_id}` (list, get, delete).
+- **Chains**: `/v1/chains`, `/v1/chains/{chain_id}` (list, get, delete).
+- **Deployments** (per-model and per-chain): list, get, delete, activate, deactivate, retry, promote, terminate replica.
+- **Environments** (per-model and per-chain): create, list, get, update (autoscaling and settings).
+- **Autoscaling**: PATCH endpoints on each deployment / environment.
+- **Instance types**: `/v1/instance_types` (list), `/v1/instance_type_prices` (pricing).
+- **Secrets**: `/v1/secrets` (list, create/update), and `/v1/teams/{team_id}/secrets` for team-scoped secrets.
+- **API keys**: `/v1/api_keys` (list, create, delete), `/v1/teams/{team_id}/api_keys`.
+- **Teams**: `/v1/teams` (list).
+- **Billing**: `/v1/billing/usage_summary`.
+- **Training**: `/v1/training_projects/...` (training jobs and checkpoints). Out of scope for this skill; see <https://docs.baseten.co/reference/training-api>.
+
+The full endpoint table with per-endpoint links is at <https://docs.baseten.co/reference/management-api/overview>.
+
+## Common patterns
+
+### List all deployments of a model
+
+```bash
+curl -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  https://api.baseten.co/v1/models/$MODEL_ID/deployments
+```
+
+### Promote a deployment into an environment
+
+```bash
+curl -X POST \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"deployment_id": "$DEPLOYMENT_ID"}' \
+  https://api.baseten.co/v1/models/$MODEL_ID/environments/production/promote
+```
+
+Related rolling-deployment controls on the same `environments/{env_name}` path: `pause_promotion`, `resume_promotion`, `force_cancel_promotion`, `force_roll_forward_promotion`, `cancel_promotion`.
+
+### Update autoscaling on production
+
+```bash
+curl -X PATCH \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"min_replicas": 1, "max_replicas": 10, "concurrency_target": 1}' \
+  https://api.baseten.co/v1/models/$MODEL_ID/deployments/production/autoscaling_settings
+```
+
+Development, production, and arbitrary deployment IDs each have their own PATCH endpoints; see the overview reference.
+
+### Activate or deactivate
+
+```bash
+curl -X POST \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  https://api.baseten.co/v1/models/$MODEL_ID/deployments/$DEPLOYMENT_ID/deactivate
+```
+
+Deactivation suspends serving (API returns 404) without deleting the deployment; reactivate with the matching `/activate` endpoint.
+
+### Manage secrets
+
+```bash
+# Create or update a workspace secret (idempotent upsert).
+curl -X POST \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "HF_ACCESS_TOKEN", "value": "hf_..."}' \
+  https://api.baseten.co/v1/secrets
+```
+
+Team-scoped secrets live under `/v1/teams/{team_id}/secrets` with the same shape.
+
+### List instance types (valid resources)
+
+```bash
+curl -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  https://api.baseten.co/v1/instance_types
+```
+
+Useful when `config.yaml`'s `instance_type` field is unclear; the returned list is the authoritative set of valid values for the workspace.
+
+## Chains
+
+Chain management mirrors models with `/v1/chains/...` in place of `/v1/models/...`. Notable differences:
+
+- Chain deployments have a combined environment update endpoint for chainlet settings (instance types, autoscaling).
+- Rolling deployments are **not supported for Chains**; promotion is an immediate traffic swap.
+
+See the Chains tab in the overview reference for the full endpoint set.
+
+## Python usage
+
+Plain `requests` is fine:
+
+```python
+import os
+import requests
+
+BASE_URL = "https://api.baseten.co"
+HEADERS = {"Authorization": f"Api-Key {os.environ['BASETEN_API_KEY']}"}
+
+
+def list_deployments(model_id: str) -> list[dict]:
+    """Return all deployments for a model."""
+    response = requests.get(
+        f"{BASE_URL}/v1/models/{model_id}/deployments",
+        headers=HEADERS,
+        timeout=30,
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+For anything non-trivial, generate a client from <https://api.baseten.co/v1/spec> rather than hand-rolling more methods. The spec is authoritative and moves faster than prose docs.
+
+## Gotchas
+
+- **`production` endpoints and environment endpoints are different surfaces.** `/v1/models/{id}/deployments/production/...` addresses the production deployment directly; `/v1/models/{id}/environments/{env_name}/...` addresses an environment (which production is one of). Pick the right one for the intended operation.
+- **Rolling deployments suspend autoscaling** for the environment for their whole duration; PATCHing autoscaling mid-rollout will not behave as expected.
+- **Only one active promotion per environment at a time.** Subsequent promotion requests are rejected until the current one completes, pauses, or is cancelled.
+- **Production cannot be deleted** unless the model itself is deleted.
+- **Deleted deployments and environments return 404** for subsequent API calls; deactivation is the reversible option.
+- **Secrets API upserts by name.** Reusing a name overwrites the existing secret's value.
+- **Authorization errors come back as 401 with `Api-Key` prefix stripped or malformed.** Double-check the prefix and the exact header name if a valid-looking key is being rejected.
+
+## Further reading
+
+- Endpoint overview: <https://docs.baseten.co/reference/management-api/overview>
+- OpenAPI spec: <https://api.baseten.co/v1/spec>
+- Deployment lifecycle concepts: `deployment-lifecycle.md` in this skill.
+- CLI (wraps many of these endpoints): `truss-cli.md` in this skill.

--- a/skills/baseten/references/model-apis.md
+++ b/skills/baseten/references/model-apis.md
@@ -1,0 +1,126 @@
+# Baseten Model APIs
+
+Model APIs are Baseten's managed catalog of pre-hosted LLMs (DeepSeek, GLM, Kimi, and others). OpenAI-compatible. No deployment step. Pay per million tokens. Pick this over a custom Truss deployment whenever a supported model does the job; you avoid packaging, infra choices, and scaling decisions entirely.
+
+This is a distinct surface from the inference API for custom deployments (see `inference-api.md`). Both speak OpenAI-compatible chat completions on their respective endpoints, but Model APIs live at a single shared endpoint regardless of which model you call, whereas custom deployments are on per-model subdomains.
+
+## Base URL and auth
+
+```
+https://inference.baseten.co/v1
+```
+
+Header on every request:
+
+```
+Authorization: Api-Key $BASETEN_API_KEY
+```
+
+API keys are created at <https://app.baseten.co/settings/account/api_keys>.
+
+Model APIs require the specific model to be **enabled** in the workspace from <https://app.baseten.co/model-apis/create> before it can be called. A 404 on the model slug usually means the model is valid but not enabled in this workspace.
+
+## Call pattern
+
+Use the official OpenAI SDK pointed at the Baseten base URL:
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="https://inference.baseten.co/v1",
+    api_key=os.environ["BASETEN_API_KEY"],
+)
+
+response = client.chat.completions.create(
+    model="deepseek-ai/DeepSeek-V3.1",
+    messages=[
+        {"role": "system", "content": "You are a concise technical writer."},
+        {"role": "user", "content": "What is gradient descent?"},
+    ],
+)
+print(response.choices[0].message.content)
+```
+
+Substitute any enabled model slug for the `model=` argument. Unlike the custom-deployment sync endpoint (where `model=` is a placeholder), **on Model APIs the `model=` field actively selects which model serves the request** - get it right.
+
+## Streaming
+
+Same as the OpenAI SDK:
+
+```python
+stream = client.chat.completions.create(
+    model="deepseek-ai/DeepSeek-V3.1",
+    messages=[{"role": "user", "content": "Write a haiku."}],
+    stream=True,
+)
+for chunk in stream:
+    delta = chunk.choices[0].delta.content
+    if delta:
+        print(delta, end="")
+```
+
+## Migrating from OpenAI
+
+Three changes to existing OpenAI code:
+
+1. API key → a Baseten key.
+2. `base_url` → `https://inference.baseten.co/v1`.
+3. Model name → a Baseten model slug.
+
+Everything else (tool calling, structured outputs, streaming, vision where supported) is the same API shape.
+
+## Feature support
+
+- **Tool calling**: supported by all models.
+- **Structured outputs**: supported by most models.
+- **Reasoning / extended thinking**: model-specific (see <https://docs.baseten.co/inference/model-apis/reasoning>).
+- **Vision**: model-specific.
+- **`top_p`, `top_k`**: GLM models and Nemotron Super support these; other models may not.
+
+Current per-model support matrix is at <https://docs.baseten.co/inference/model-apis/overview#feature-support>.
+
+## Listing models
+
+```
+curl https://inference.baseten.co/v1/models \
+  -H "Authorization: Api-Key $BASETEN_API_KEY"
+```
+
+Returns current slugs with metadata (context lengths, pricing, features).
+
+## Pricing
+
+Pricing moves; defer to the current table at <https://docs.baseten.co/inference/model-apis/overview#pricing>.
+
+## Error codes
+
+Standard HTTP:
+
+| Code | Meaning |
+|---|---|
+| 400 | Invalid request (check parameters) |
+| 401 | Invalid or missing API key |
+| 402 | Payment required |
+| 404 | Model not found (or not enabled in this workspace) |
+| 429 | Rate limit exceeded |
+| 500 | Internal server error |
+
+## Gotchas
+
+- **Models must be enabled in the workspace** before they can be called. 404 on a valid slug usually means "not enabled here", not "does not exist on Baseten".
+- **The base URL differs from custom deployments.** Model APIs live at `inference.baseten.co`; custom deployments live at `model-{id}.api.baseten.co`. Swapping one for the other will fail.
+- **The `model=` field is meaningful here.** It picks the model. (On custom deployments it is a placeholder.)
+- **Auth header is `Authorization: Api-Key <key>`, not `Bearer <key>`.** OpenAI SDK handles this automatically; hand-rolled HTTP must use the `Api-Key` prefix.
+- **Prefix caching is on by default.** Requests sharing a prefix with a recent request will see cache behavior; see the pricing docs for how that maps to billing.
+
+## Further reading
+
+- Model APIs overview: <https://docs.baseten.co/inference/model-apis/overview>
+- Chat completions reference: <https://docs.baseten.co/reference/inference-api/chat-completions>
+- Structured outputs: <https://docs.baseten.co/inference/structured-outputs>
+- Tool calling: <https://docs.baseten.co/inference/function-calling>
+- Reasoning: <https://docs.baseten.co/inference/model-apis/reasoning>
+- Rate limits and budgets: <https://docs.baseten.co/inference/model-apis/rate-limits-and-budgets>
+- Custom deployments (when a managed model is not a fit): `inference-api.md` in this skill.

--- a/skills/baseten/references/truss-chains.md
+++ b/skills/baseten/references/truss-chains.md
@@ -1,0 +1,132 @@
+# Baseten Chains
+
+Chains is the framework for orchestrating multi-step inference pipelines on Baseten where each step has different hardware, dependency, or scaling needs. Pick Chains when a single monolithic Truss does not fit: RAG, multi-model pipelines (e.g. LLM then TTS then transcription), audio or video chunking and reassembly, image generation with safety or upscaling steps, retrieval into an LLM.
+
+Each step in a Chain is a **Chainlet**: a Python class that deploys independently on its own hardware with its own autoscaling policy. One Chainlet is marked as the **entrypoint** and handles the Chain's public HTTP surface.
+
+Reference docs live at <https://docs.baseten.co/development/chain/overview> and the CLI reference at <https://docs.baseten.co/reference/cli/chains/chains-cli>. For deeper patterns (streaming, binary I/O, error handling, subclassing), defer to the docs.
+
+## Minimal example
+
+The "hello world" Chain from <https://docs.baseten.co/development/chain/getting-started>:
+
+```python
+import random
+import truss_chains as chains
+
+
+class RandInt(chains.ChainletBase):
+    async def run_remote(self, max_value: int) -> int:
+        return random.randint(1, max_value)
+
+
+@chains.mark_entrypoint
+class HelloWorld(chains.ChainletBase):
+    def __init__(self, rand_int=chains.depends(RandInt, retries=3)) -> None:
+        self._rand_int = rand_int
+
+    async def run_remote(self, max_value: int) -> str:
+        num_repetitions = await self._rand_int.run_remote(max_value)
+        return "Hello World! " * num_repetitions
+```
+
+Deploy:
+
+```
+truss chains push --watch hello.py
+```
+
+Call (URL is printed by `push`):
+
+```
+curl -X POST $INVOCATION_URL \
+  -H "Authorization: Api-Key $BASETEN_API_KEY" \
+  -d '{"max_value": 10}'
+```
+
+## The Chainlet contract
+
+- Subclass `truss_chains.ChainletBase`.
+- Expose exactly one public method, `run_remote`. It is the Chainlet's API.
+- `run_remote` must be **fully type-annotated** with primitive Python types (`int`, `str`, `list[float]`, ...) or Pydantic models. Annotations drive serialization across Chainlets and into the public API.
+- Mark exactly one Chainlet with `@chains.mark_entrypoint`. That Chainlet's `run_remote` is the Chain's public HTTP endpoint.
+- Chainlets cannot be instantiated naively (`RandInt()`). The only valid ways to use another Chainlet are:
+  - declare it as an `__init__` argument via `chains.depends(OtherChainlet, retries=...)`, or
+  - drive it through local debugging mode (<https://docs.baseten.co/development/chain/localdev>).
+- Beyond `run_remote`, you can structure the class however you like: private methods, imports from other files, Pydantic models, etc.
+
+## Per-Chainlet resources
+
+Each Chainlet declares its own hardware and dependencies via `remote_config`:
+
+```python
+class PhiLLM(chains.ChainletBase):
+    remote_config = chains.RemoteConfig(
+        docker_image=chains.DockerImage(
+            pip_requirements=[
+                "accelerate==0.30.1",
+                "transformers==4.41.2",
+                "torch==2.3.0",
+            ],
+        ),
+        compute=chains.Compute(cpu_count=2, gpu="T4"),
+        assets=chains.Assets(cached=[model_repo]),
+    )
+```
+
+`compute`, `docker_image`, and `assets` are the common knobs; `assets.cached` bakes model weights into the image at build time, same idea as the `model_cache` block in a classic Truss `config.yaml`. The full API surface is at <https://docs.baseten.co/reference/sdk/chains>.
+
+## Heavy-dependency imports
+
+Imports of Chainlet-specific packages (e.g. `torch`, `transformers`) commonly live **inside** `__init__` or `run_remote` rather than at module top, because those packages are only available in the remote Chainlet image, not in the local dev environment.
+
+```python
+def __init__(self) -> None:
+    import torch
+    import transformers
+    ...
+```
+
+This is a local exception to the general rule of keeping imports at module top: the constraint is that top-level imports run in the local dev shell, which need not have GPU libraries installed.
+
+## Deploy
+
+```
+truss chains push [--watch] <chain.py>
+```
+
+`--watch` gives a development deployment with live reload. `truss chains push` without `--watch` deploys a published Chain; see <https://docs.baseten.co/reference/cli/chains/chains-cli> for environment/promotion flags. The output lists each Chainlet's status and log URL, plus the invocation URL for the entrypoint.
+
+## Calling a deployed Chain
+
+The entrypoint's `run_remote` is exposed at a URL of the shape:
+
+```
+https://chain-{chain_id}.api.baseten.co/.../run_remote
+```
+
+Use standard HTTP with an `Authorization: Api-Key $BASETEN_API_KEY` header. Body is the JSON-encoded arguments to `run_remote`.
+
+For streaming, binary I/O, and websockets, see:
+
+- <https://docs.baseten.co/development/chain/streaming>
+- <https://docs.baseten.co/development/chain/binaryio>
+
+## Gotchas
+
+- **Rolling deployments are not supported for Chains.** Plan promotions accordingly; there is no gradual traffic shift between versions.
+- **Chainlets cannot be instantiated directly.** Always use `chains.depends()` in `__init__` arguments, or the documented local debugging path.
+- **Full type annotations on `run_remote` are required** for serialization. Un-annotated parameters will not work.
+- **Avoid module-level global state and dynamic imports in Chainlet code.** Chainlets are distributed and replicated; globals do not behave the way you might expect.
+- **Per-Chainlet autoscaling is independent.** A slow downstream Chainlet can become the bottleneck; tune its `autoscaling` separately from the entrypoint.
+- **Local imports of heavy dependencies** (`torch`, `transformers`, etc.) inside `__init__` or `run_remote` are idiomatic for Chains even though they contradict the general "imports at top" rule - those libs live in the remote image, not the local dev shell.
+
+## Further reading
+
+- Chains overview: <https://docs.baseten.co/development/chain/overview>
+- Getting started (Hello World + Poetry examples): <https://docs.baseten.co/development/chain/getting-started>
+- Concepts and `run_remote` chaining: <https://docs.baseten.co/development/chain/concepts>
+- SDK reference (`ChainletBase`, `depends`, `RemoteConfig`, `Compute`, `Assets`): <https://docs.baseten.co/reference/sdk/chains>
+- CLI reference: <https://docs.baseten.co/reference/cli/chains/chains-cli>
+- Local development: <https://docs.baseten.co/development/chain/localdev>
+- Example Chains (audio transcription, RAG): <https://docs.baseten.co/examples/chains-audio-transcription> and <https://docs.baseten.co/examples/chains-build-rag>

--- a/skills/baseten/references/truss-cli.md
+++ b/skills/baseten/references/truss-cli.md
@@ -1,0 +1,145 @@
+# `truss` CLI
+
+The `truss` CLI builds, deploys, and live-patches Trusses. The published reference is at <https://docs.baseten.co/reference/cli/truss/overview>.
+
+This file covers Truss model commands only. For the `truss chains` subcommand group, see `truss-chains.md` in this skill. The `truss train` group (Truss Train) is not covered in this skill; see <https://docs.baseten.co/reference/cli/training>.
+
+## Install
+
+See the "Installing the truss CLI" section of SKILL.md. Short version: `uv tool install truss` (or `uvx truss <command>` to run without installing); `pip install truss` also works.
+
+## Authenticate
+
+```
+truss login
+```
+
+Paste an API key from <https://app.baseten.co/settings/account/api_keys> when prompted. Truss stores credentials in `.trussrc` for future commands. In CI, set `BASETEN_API_KEY` and use `--remote` to select the saved remote name.
+
+## `truss init` - scaffold
+
+```
+truss init my-model
+```
+
+Creates a starter Truss directory:
+
+```
+my-model/
+├── config.yaml
+├── model/
+│   ├── __init__.py
+│   └── model.py
+├── data/
+└── packages/
+```
+
+Edit `model/model.py` (Python class flavor), or replace it with `docker_server` config (custom server flavor), or remove it entirely and add an engine block (engine-only).
+
+## `truss push` - the main flow
+
+`truss push` is the workhorse. Default behavior creates a **published** deployment (immutable snapshot). Use flags to change target, control live reload, wait for completion, and stream logs.
+
+### Common patterns
+
+Iterative dev loop (live-patches code on save):
+
+```
+truss push --watch --tail
+```
+
+CI-friendly publish that waits and streams logs:
+
+```
+truss push --wait --tail
+```
+
+CI-friendly publish with machine-readable output (intended for automation):
+
+```
+truss push --json --wait
+```
+
+Promote straight to production:
+
+```
+truss push --promote
+```
+
+Promote to a named environment:
+
+```
+truss push --environment staging
+```
+
+### Key flags
+
+- `--watch`: create a **development** deployment and watch for source changes, applying live patches. The dev model stays warm by default (no scale-to-zero) while watching.
+- `--watch-hot-reload`: with `--watch`, swap the model class in-process instead of restarting the server. Faster iteration; preserves loaded weights and caches; does **not** re-run `__init__` or `load`. Use when you only changed `predict` logic.
+- `--promote`: published deployment, promoted to production even if a production deployment already exists.
+- `--environment <name>`: published deployment, promoted into the named environment. When set, `--promote` is ignored.
+- `--preserve-previous-production-deployment`: with `--promote`, inherit the previous production deployment's autoscaling settings.
+- `--preserve-env-instance-type` / `--no-preserve-env-instance-type`: with `--environment`, keep the environment's configured instance type instead of the Truss config's `resources`. Default is to preserve.
+- `--deployment-name <name>`: name the published deployment (alphanumeric, `.`, `-`, `_`). Ignored for `--watch`.
+- `--model-name <name>`: temporarily override `model_name` without editing `config.yaml`.
+- `--wait` / `--no-wait`: block until the deploy finishes; exit non-zero on failure.
+- `--tail`: stream deployment logs after push. Combines with `--wait` and with `--watch`.
+- `--json`: emit structured output suitable for CI parsing.
+- `--labels '{"k":"v"}'`: attach searchable key/value labels to the deployment.
+- `--include-git-info`: attach git sha, branch, and tag.
+- `--no-cache`: force a full rebuild without using cached layers.
+- `--timeout-seconds <n>`: client-side polling timeout when `--wait`-ing.
+- `--deploy-timeout-minutes <n>`: server-side deploy timeout.
+- `--remote <name>`: pick a remote from `.trussrc`. Useful in CI with multiple workspaces.
+- `--config <path>`: use a non-default config file.
+- `--team <name>`: deploy to a specific team (organizations with teams enabled).
+
+## `truss watch` - re-attach to a dev deployment
+
+```
+truss watch
+```
+
+Re-attaches to an existing development deployment and applies live patches when files change. Equivalent to running `truss push --watch` once and resuming the watch loop later.
+
+`truss watch` keeps the dev deployment **warm** (prevents scale-to-zero) while it is running. If the user expects the dev deployment to scale to zero while a watch is active, surface this so they understand why replicas are still running.
+
+Other flags:
+
+- `--hot-reload`: in-process model swap, same semantics as `--watch-hot-reload` on push.
+- `--remote`, `--config`, `--team`, `--model-name`: same meanings as on `push`.
+
+## `truss container` - local debugging
+
+`truss container` builds and runs the Truss as a Docker container locally. Use this to reproduce build failures or inspect the model server outside of Baseten.
+
+## `truss image` - build and manage images
+
+`truss image build` produces the Docker image without deploying. Useful for checking what gets shipped, or for offline image distribution.
+
+## `truss model-logs` - fetch deployment logs
+
+```
+truss model-logs <model-id>
+```
+
+Fetches recent logs for a deployment. For continuous streaming during a push, prefer `truss push --tail`.
+
+## `truss configure`, `truss whoami`, `truss cleanup`
+
+Workspace and account utilities. `whoami` prints the current authenticated user. `configure` manages remotes in `.trussrc`. `cleanup` removes locally cached deployment artifacts.
+
+## Gotchas
+
+- **Default `truss push` is a published deployment, not a dev one.** For an iterative dev loop, use `--watch` (or `truss watch` afterwards).
+- **`truss watch` keeps the dev deployment warm by default.** Replicas do not scale to zero while the watch is running. Stop the watch (or accept the cost) accordingly.
+- **`--watch-hot-reload` does not re-run `__init__` or `load`.** If your change relies on new state set up there, do a full reload (omit `--watch-hot-reload`) instead.
+- **`.trussrc` holds credentials.** Do not commit it. In CI, prefer `BASETEN_API_KEY` plus `--remote <name>` over committing `.trussrc`.
+
+## Further reading
+
+- CLI overview: <https://docs.baseten.co/reference/cli/truss/overview>
+- `truss push` reference: <https://docs.baseten.co/reference/cli/truss/push>
+- `truss watch` reference: <https://docs.baseten.co/reference/cli/truss/watch>
+- Deploy and iterate guide: <https://docs.baseten.co/development/model/deploy-and-iterate>
+- Calling deployed models (when ready to test from outside the CLI): see `inference-api.md` in this skill.

--- a/skills/baseten/references/truss-config.md
+++ b/skills/baseten/references/truss-config.md
@@ -1,0 +1,138 @@
+# `config.yaml`
+
+`config.yaml` sits at the root of a Truss directory and describes how a model is built and served: its name, runtime, hardware, packages, secrets, and (for non-Python flavors) the Docker or engine configuration that stands in for `model.py`.
+
+A `config.yaml` on its own does not produce a working deployment. It must be paired with one of:
+
+- a Python `model.py` (the Python-class flavor, see `truss-model-py.md`), or
+- a `docker_server` block pointing at a custom HTTP server (see `truss-custom-servers.md`), or
+- an engine block such as `trt_llm` for an engine-only deploy (see the engine-only section below).
+
+The authoritative schema is the Pydantic-backed JSON schema in the Truss repo:
+
+- <https://github.com/basetenlabs/truss/blob/main/truss/config.schema.json>
+
+Grep or read that file before guessing about an obscure field. The public reference page is <https://docs.baseten.co/reference/truss-configuration>.
+
+## A typical example
+
+All fields in this example are optional at the schema level, but most real Trusses have at least these:
+
+```yaml
+model_name: my-model
+python_version: py311
+requirements:
+  - transformers==4.44.0
+  - torch==2.4.0
+resources:
+  accelerator: L4
+  use_gpu: true
+```
+
+`model_name` is effectively required for a usable deployment (it identifies the model in the workspace). `python_version` is strongly recommended - omitting it relies on whatever default the current Truss release ships. `requirements`, `resources`, and other blocks are per-flavor and per-need, not universally required.
+
+## Core fields
+
+- `model_name` (str): display name in the Baseten workspace.
+- `python_version` (str): one of `py39`, `py310`, `py311`, etc. Determines the base image's Python.
+- `requirements` (list[str]): pip packages. Prefer pinned versions for reproducible builds.
+- `requirements_file` (str): path to a `requirements.txt` instead of inline `requirements`. Use one or the other, not both.
+- `system_packages` (list[str]): `apt-get` packages installed into the image (e.g. `ffmpeg`, `libsndfile1`).
+- `environment_variables` (map[str, str]): env vars set in the container. Do not put secret values here.
+- `external_package_dirs` (list[str]): local directories copied into the image and added to `PYTHONPATH`.
+- `build_commands` (list[str]): shell commands run at image build time (before model load).
+- `data_dir` / `external_data`: bundle static data with the model. `external_data` pulls from a URL at build time.
+
+## `resources` block
+
+Controls hardware. Two ways to specify, choose one:
+
+```yaml
+resources:
+  cpu: "4"
+  memory: "16Gi"
+  accelerator: L4
+  use_gpu: true
+```
+
+or
+
+```yaml
+resources:
+  instance_type: "L4:4x16"   # GPU:vCPUxMEMORY_GiB
+```
+
+If both are set, `instance_type` wins and overrides `cpu`, `memory`, `accelerator`.
+
+Accelerator naming (exact strings the platform accepts):
+
+- Single GPU: `L4`, `A10G`, `A100`, `H100`, `H200`, `B200`.
+- Multi-GPU: append `:N`, for example `H100:2`, `A100:8`, `B200:4`.
+- H100 / H200 `instance_type` strings use just `"H100:2"` (no vCPU/RAM suffix); other GPUs take `"L4:4x16"` style.
+
+For the full current list of instance types, see <https://docs.baseten.co/deployment/resources> and the management API instance-types endpoint.
+
+## `secrets` block
+
+Secrets in `config.yaml` are declared by **name**, not by value. The value is stored in the Baseten workspace and injected into the container at runtime.
+
+```yaml
+secrets:
+  hf_access_token: null           # or a placeholder string, never the real token
+  openai_api_key: null
+```
+
+In `model.py`, read them from the `secrets` dict passed to `__init__`. In a `docker_server` deployment, Baseten mounts secret values to files under a configurable path (see `truss-custom-servers.md`). Never commit a real secret value to `config.yaml`.
+
+## `model_cache` (large weights)
+
+Heavy models should download weights at **image build** time, not at model load, so replicas cold-start fast.
+
+```yaml
+model_cache:
+  - repo_id: meta-llama/Llama-3.1-8B-Instruct
+    revision: main
+    allow_patterns:
+      - "*.safetensors"
+      - "tokenizer*"
+      - "*.json"
+```
+
+The weights are baked into the image (or a layer) and available on disk when the container starts. Pair with a Hugging Face access secret if the repo is gated.
+
+## `docker_server` block (custom server flavor)
+
+When `docker_server:` is set, Baseten runs a user-defined HTTP server (vLLM, TGI, SGLang, Triton, etc.) instead of the Python Truss server. See `truss-custom-servers.md` for the full field list; in short you specify `start_command`, `server_port`, `predict_endpoint`, `readiness_endpoint`, `liveness_endpoint`, `base_image`, and `run_as_user_id`.
+
+## Engine-only deploys
+
+Engine-only deployments skip `model.py` and skip a custom server: the engine runs the model directly from `config.yaml`.
+
+- **TensorRT-LLM** via the `trt_llm` block. Fields include `max_batch_size`, `quantization_type`, `tensor_parallel_count`, `num_builder_gpus`. Tradeoffs and valid value ranges are not all documented centrally; read <https://docs.baseten.co/engines> and the schema file for the current surface.
+- **Baseten Embedding Inference (BEI)**: embedding-model engine, OpenAI-compatible `/v1/embeddings` endpoint.
+- **Baseten Inference Stack LLM (BIS-LLM)** and **Engine-Builder-LLM**: LLM engines, OpenAI-compatible `/v1/chat/completions` endpoint.
+
+When to pick which engine, and the exact `config.yaml` shape for each, is covered on the docs site under `/engines`. Confirm with the user which engine they want before generating config; do not guess.
+
+## `runtime`, `build`, and advanced blocks
+
+- `runtime`: predict concurrency, timeouts, streaming buffering settings.
+- `build`: `model_server` selection (defaults to `TrussServer`), build-time options, secret-to-file mapping for `docker_server`.
+- `live_reload`, `apply_library_patches`, `weights`, `training_checkpoints`: advanced features. Consult the schema or docs before using.
+
+## Gotchas
+
+- **Secrets are names, not values.** Never put a real token in `config.yaml`.
+- **`instance_type` overrides `cpu`/`memory`/`accelerator`.** Setting both is confusing; pick one style.
+- **`model_metadata.example_model_input` is publicly visible** on the deployment. Do not put credentials, PII, or internal data there.
+- **`model_cache` downloads at build time, not load time.** If the user complains about slow cold starts, check whether weights are coming from disk or downloading at load.
+- **Gated Hugging Face repos need a secret** (`hf_access_token` is the conventional name) **and** the secret must be configured in the workspace.
+- **Pinned Python, pinned packages.** Unpinned `requirements` produce non-reproducible builds; mismatched `python_version` and a package's wheels lead to slow source builds or install failures.
+
+## Further reading
+
+- Config schema (authoritative): <https://github.com/basetenlabs/truss/blob/main/truss/config.schema.json>
+- Docs reference: <https://docs.baseten.co/reference/truss-configuration>
+- Resources and instance types: <https://docs.baseten.co/deployment/resources>
+- Engines overview: <https://docs.baseten.co/engines>
+- Real examples: <https://github.com/basetenlabs/truss-examples>

--- a/skills/baseten/references/truss-custom-servers.md
+++ b/skills/baseten/references/truss-custom-servers.md
@@ -1,0 +1,134 @@
+# Custom Docker server Truss
+
+The custom-server flavor wraps a pre-built HTTP inference server (vLLM, TGI, SGLang, Triton, Ollama, NIM, anything that listens on HTTP) instead of running Python in the request path. Pick it when an off-the-shelf server already does what the user needs; it is often the most popular path for modern LLM deployments.
+
+A custom-server Truss has no `model.py`. The `config.yaml` declares a `base_image` and a `docker_server` block; Truss builds (or, with `no_build`, ships verbatim) and Baseten runs the resulting image.
+
+## The `docker_server` block
+
+```yaml
+base_image:
+  image: your-registry/your-image:latest
+docker_server:
+  start_command: your-server-start-command
+  server_port: 8000
+  predict_endpoint: /predict
+  readiness_endpoint: /health
+  liveness_endpoint: /health
+```
+
+Field meanings (from the published reference):
+
+- `image` (under `base_image`): the Docker image to use.
+- `start_command`: command to start the server. Overrides the base image's default entrypoint.
+- `server_port`: the port your server listens on.
+- `predict_endpoint`: the path inside your server that Baseten maps `/predict` to.
+- `readiness_endpoint`: path Baseten polls to check the server is ready to serve traffic.
+- `liveness_endpoint`: path Baseten polls to check the server is still alive.
+
+Full field list (private registries, advanced options, etc.) lives at <https://docs.baseten.co/reference/truss-configuration#docker_server>.
+
+## Worked example: Ollama with TinyLlama
+
+This example is the published custom-server walkthrough at <https://docs.baseten.co/development/model/custom-server>. TinyLlama runs on CPU.
+
+```yaml
+model_name: ollama-tinyllama
+base_image:
+  image: python:3.11-slim
+build_commands:
+  - apt-get update && apt-get install -y curl ca-certificates zstd
+  - curl -fsSL https://ollama.com/install.sh | sh
+docker_server:
+  start_command: sh -c "ollama serve & sleep 5 && ollama pull tinyllama && wait"
+  readiness_endpoint: /api/tags
+  liveness_endpoint: /api/tags
+  predict_endpoint: /api/generate
+  server_port: 11434
+resources:
+  cpu: "4"
+  memory: 8Gi
+```
+
+Deploy with `truss push`; calls to `/predict` are forwarded to Ollama's `/api/generate`.
+
+For ready-made server walkthroughs, see:
+
+- vLLM: <https://docs.baseten.co/examples/vllm>
+- SGLang: <https://docs.baseten.co/examples/sglang>
+- TensorRT-LLM (also doable as engine-only): <https://docs.baseten.co/examples/tensorrt-llm>
+
+## Endpoint mapping
+
+`predict_endpoint` only handles the `/predict` route. To hit any other path on your server, use Baseten's sync endpoint:
+
+| Baseten endpoint | Maps to |
+|---|---|
+| `/environments/production/predict` | Your `predict_endpoint` route |
+| `/environments/production/sync/{any/route}` | `/{any/route}` in your server |
+
+Example: with `predict_endpoint: /v1/chat/completions`, calling `/environments/production/sync/v1/models` reaches `/v1/models` in your server. This makes it possible to expose OpenAI-compatible servers (which need both `/v1/chat/completions` and `/v1/models`) cleanly.
+
+## Non-root user (`run_as_user_id`)
+
+Some base images expect a specific non-root UID (NVIDIA NIM and Triton run as `1000`).
+
+```yaml
+docker_server:
+  start_command: ...
+  server_port: 8000
+  predict_endpoint: /predict
+  readiness_endpoint: /health
+  liveness_endpoint: /health
+  run_as_user_id: 1000
+```
+
+The UID must already exist in the base image. Values `0` (root) and `60000` (Baseten's platform default) are not allowed. Baseten sets ownership of `/app`, `/workspace`, the packages directory, and `$HOME` to the specified UID. Anything else your server writes to must be made writable by that UID via the base image or `build_commands`.
+
+## No-build deployment
+
+For security-hardened images that must remain unmodified, set `no_build: true` to skip `docker build`. Baseten copies the image to its registry as-is.
+
+```yaml
+base_image:
+  image: your-registry/your-hardened-image:latest
+docker_server:
+  no_build: true
+  server_port: 8000
+  predict_endpoint: /predict
+  readiness_endpoint: /health
+  liveness_endpoint: /health
+```
+
+Constraints:
+
+- Custom server only. `model.py`-based Trusses cannot use `no_build`.
+- Not enabled by default for an organization; the user must contact Baseten support to turn it on.
+- Development mode is not supported; deploy with plain `truss push`.
+- Truss config fields beyond `docker_server`, `base_image`, `environment_variables`, `secrets`, and `data` are not injected. Pass other configuration as environment variables.
+- `start_command` is optional; if omitted, the image's original `ENTRYPOINT` runs.
+- Path remapping is skipped: `predict_endpoint` is required but has no effect, and all server paths are reachable via `/environments/production/sync/<path>`.
+
+## Secrets
+
+Secrets declared in `config.yaml` are available to custom servers; the mount path is configurable. See <https://docs.baseten.co/development/model/secrets#custom-docker-images> for the exact mechanism (environment-variable vs file-mounted depending on configuration).
+
+## Per-request logging
+
+Baseten assigns a unique request ID per call and returns it in the `X-Baseten-Request-Id` response header. Standard Python Trusses log this automatically; **custom servers must extract it from the incoming `X-Baseten-Request-Id` request header and include it as a top-level `request_id` field in JSON-formatted logs written to stdout**. Without that, per-request log filtering does not work. FastAPI and Flask snippets are at <https://docs.baseten.co/development/model/custom-server#per-request-logging>.
+
+## Gotchas
+
+- **Port 8080 is reserved** by Baseten's internal reverse proxy. A server bound to 8080 fails with `[Errno 98] address already in use`. Choose any other port.
+- **`run_as_user_id` cannot be `0` or `60000`.** Match what the base image actually uses.
+- **No-build needs to be enabled** by support before it works for the organization.
+- **Custom servers do not get automatic per-request log correlation.** If users need it, they must format logs as JSON with a `request_id` key.
+- **`predict_endpoint` is required even when no-build skips remapping.** Treat it as documentation of your primary inference route.
+
+## Further reading
+
+- Custom Docker images: <https://docs.baseten.co/development/model/custom-server>
+- Config reference (`docker_server`, `base_image`, `no_build`): <https://docs.baseten.co/reference/truss-configuration>
+- Private registries: <https://docs.baseten.co/development/model/private-registries>
+- Calling deployed models (sync/async/streaming): <https://docs.baseten.co/inference/calling-your-model>
+- Examples: <https://github.com/basetenlabs/truss-examples>

--- a/skills/baseten/references/truss-model-py.md
+++ b/skills/baseten/references/truss-model-py.md
@@ -1,0 +1,117 @@
+# Python-class Truss (`model.py`)
+
+The Python-class flavor runs user-written Python in the request path via a `Model` class with three methods. Pick it when you need Python pre- or post-processing, custom architectures not covered by an engine, or anything that doesn't fit a ready-made HTTP server.
+
+If an off-the-shelf server (vLLM, TGI, SGLang, Triton) or a Baseten engine (TensorRT-LLM, BEI, BIS-LLM) does the job, prefer those instead. See `truss-custom-servers.md` and `truss-config.md` (engines section).
+
+This skill covers the core contract. Sophisticated streaming patterns, custom batching, and performance tuning of the in-process server are intentionally out of scope; consult <https://docs.baseten.co/development/model> and the examples repo for those.
+
+## Directory shape
+
+```
+my-model/
+├── config.yaml
+├── model/
+│   └── model.py
+├── packages/          # optional: local Python packages copied into the image
+└── data/              # optional: static data bundled with the model
+```
+
+`truss init my-model` generates this scaffold.
+
+## The `Model` class
+
+The official starter template (from `truss init`) is:
+
+```python
+class Model:
+    def __init__(self, **kwargs):
+        # self._data_dir = kwargs["data_dir"]
+        # self._config = kwargs["config"]
+        # self._secrets = kwargs["secrets"]
+        self._model = None
+
+    def load(self):
+        # Load model here and assign to self._model.
+        pass
+
+    def predict(self, model_input):
+        # Run model inference here
+        return model_input
+```
+
+### What `__init__` receives
+
+Truss inspects the `__init__` signature and passes only the keyword arguments it explicitly accepts. The recognized names (per `truss/templates/server/model_wrapper.py`) are:
+
+- `config`: parsed `config.yaml` as a dict.
+- `data_dir`: path to the bundled `data/` directory.
+- `secrets`: dict mapping declared secret name to value.
+- `lazy_data_resolver`: helper for lazily-resolved external data.
+- `environment`: information about the environment the deployment is attached to (e.g. `production`), or `None`.
+
+Two equivalent styles:
+
+```python
+def __init__(self, **kwargs):           # receive everything Truss provides
+    self._secrets = kwargs.get("secrets", {})
+
+def __init__(self, secrets, config):    # receive only what you name
+    self._secrets = secrets
+```
+
+### `load`
+
+Runs once after `__init__`, before the server accepts requests. Load weights and other heavy resources here so the readiness check correctly gates traffic.
+
+### `predict`
+
+Runs per request. Receives the request body (typically a dict). Returns a dict, bytes, or a generator (see streaming below).
+
+## Worked examples
+
+For real model code, do not invent it. Read the examples repo, where each model directory has a complete `config.yaml` plus `model/model.py`:
+
+- <https://github.com/basetenlabs/truss-examples>
+
+Common starting points include the LLM examples (e.g. Mistral, Llama variants), image generation (SDXL), and multimodal pipelines.
+
+## Streaming responses
+
+Return a generator from `predict` to stream chunks. The server emits them as a streaming HTTP response; clients read with `requests` + `iter_content`, SSE parsers, or the OpenAI SDK for OpenAI-compatible payloads.
+
+```python
+def predict(self, model_input):
+    prompt = model_input["prompt"]
+    for token in self._stream_tokens(prompt):
+        yield token
+```
+
+See <https://docs.baseten.co/inference/streaming> for the client side.
+
+## Async `predict`
+
+`predict` may be `async def` for I/O-bound work (e.g. calling external services inside the request). Baseten's server awaits it appropriately. CPU- or GPU-bound model work should stay sync or offload via a thread pool.
+
+## Binary output
+
+Return `bytes` from `predict` to emit a binary response (e.g. an image, audio clip). Set headers via the `starlette` response helpers if you need specific `Content-Type`; see the examples repo for patterns.
+
+## Accessing secrets and `data_dir`
+
+- `self._secrets["name"]` pulls values for secrets declared in `config.yaml`.
+- `self._data_dir` is a `pathlib.Path` to the bundled `data/` directory. Use it for tokenizers, small aux files, or anything baked into the image.
+
+## Gotchas
+
+- **Load weights in `load`, not `__init__`.** The server uses `load()` completion to gate readiness; weight loading in `__init__` delays startup without the benefit of the readiness gate.
+- **`predict` runs per request.** Do not reload the model or re-open heavy resources inside it.
+- **`predict_concurrency` and `num_workers`** live in `config.yaml` under `runtime`. If a sync `predict` does long blocking work, concurrency settings determine throughput; consult the docs when tuning.
+- **Logs go to stdout/stderr.** Use ordinary `logging` or `print`; Baseten captures them.
+- **Local packages live in `packages/`**, not in `requirements`. Add the directory to `external_package_dirs` in `config.yaml`.
+
+## Further reading
+
+- <https://docs.baseten.co/development/model> (custom model code, lifecycle, streaming, async)
+- <https://docs.baseten.co/inference/streaming>
+- Real examples: <https://github.com/basetenlabs/truss-examples>


### PR DESCRIPTION
# What Changed

* Added new skill called `baseten`
  * Why a baseten skill instead of several individual skills? Because the persona of "model operator" is the same across the skill and there was 
  * More skills can be added later
* Added README and some CONTRIBUTING info and eval structure

Since this is in branch, to test you can:

```
git clone -b initial-skill https://github.com/basetenlabs/baseten-skills.git
npx skills add ./baseten-skills --skill baseten --global --yes
```
and to remove
```
npx skills remove ./baseten-skills --skill baseten --global --yes
```

Looking for all manner of feedback here as I am not a baseten expert