### PR TITLE
Replace deprecated 'npx add-skill' with 'npx skills add'

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ export BASETEN_MCP_KEY=...
 { [ -n "$BASETEN_MCP_KEY" ] && [ "$BASETEN_MCP_KEY" != "..." ]; } || { echo "Error: set BASETEN_MCP_KEY first"; false; } && \
 npx add-mcp https://api.baseten.co/mcp -g -y --header "Authorization: Bearer ${BASETEN_MCP_KEY}" && \
 npx add-mcp https://docs.baseten.co/mcp -n "baseten_docs" -g -y && \
-npx add-skill basetenlabs/baseten-skills -g -y
+npx skills add basetenlabs/baseten-skills -g -y
 ```
 
 `-g` installs it globally on your host and `-y` confirms selection for all detected harnesses. If your harness

--- a/skills/baseten/SKILL.md
+++ b/skills/baseten/SKILL.md
@@ -25,7 +25,7 @@ cross-cloud HA, and seamless developer workflows.
 | `baseten_docs` MCP | Lexical/keyword search of `docs.baseten.co`. No auth. | `npx add-mcp https://docs.baseten.co/mcp -n "baseten_docs" -g -y` |
 | `truss` CLI | Needed for model/chain push from local code, watch (= live patch). Needs `truss login` once. | `pip install truss --upgrade` (respect user package manager: uv, poetry...) |
 | `llms.txt` | `baseten.co/llms.txt` (product + blog), `docs.baseten.co/llms.txt` (docs). | reachable via HTTP |
-| This skill | `SKILL.md` + `references/*.md` loaded on demand. | `npx add-skill basetenlabs/baseten-skills -g -y` |
+| This skill | `SKILL.md` + `references/*.md` loaded on demand. | `npx skills add basetenlabs/baseten-skills -g -y` |
 
 ### Setup
 


### PR DESCRIPTION
## Summary

- `add-skill` npm package is deprecated (renamed to `skills`); npm now prints `DEPRECATED: Use 'npx skills add' instead`.
- Update the two install snippets (`README.md`, `skills/baseten/SKILL.md`) accordingly.

## Test plan

- [ ] `npx skills add basetenlabs/baseten-skills -g -y` resolves and installs.