### PR TITLE
Improve agent guidance, prereqs, watcher recipe, Chains pitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,20 @@ Instruct AI coding agents to use Baseten effectively - route to the right tools 
 
 ## Skills
 
-- [`baseten`](skills/baseten) - deploying, configuring, calling, and operating models on Baseten. Covers Truss
-  authoring, the `truss` CLI, Chains, environments / rolling deployments, pre-hosted Model APIs, and the inference +
+- [`baseten`](skills/baseten) - deploying, configuring, calling, and operating models on Baseten. Covers deployment
+  authoring, the `truss` CLI, Chains, environments, rolling deployments, pre-hosted Model APIs, and the inference +
   management APIs.
 
 ## Install
 
-Below command performs setup for all common coding harnesses. For interacting with your Baseten workspace, provide an
-API key (you can get it from the [webapp](https://app.baseten.co/settings/api_keys)):
+Below command performs setup for all common coding harnesses.
+
+### Requirements:
+
+* For interacting with your Baseten workspace, provide an API key with management permissions (you can get it from the 
+  [webapp](https://app.baseten.co/settings/api_keys)). We recommend using a purpose-dedicated key so it can be 
+  independently revoked without impacting your other workstreams.
+* Node >= 18
 
 ```bash
 export BASETEN_MCP_KEY=...
@@ -28,7 +34,7 @@ npx skills add basetenlabs/baseten-skills -g -y
 
 `-g` installs it globally on your host and `-y` confirms selection for all detected harnesses. If your harness
 supports env variable interpolation, you may also edit the MCP config file to expand your env vars and set the
-desired key in the shell that starts the agent.
+desired key in the shell that starts the agent. 
 
 The `truss` CLI is separate - needed for pushing models / chains from local code, see
 [CLI docs](https://docs.baseten.co/reference/cli/truss/overview). E.g. if you use pip (similar for other package
@@ -45,7 +51,9 @@ models from your local files) - but the best user experience comes from their co
 
 After installation, most agents require a restart.
 
-Check if the MCP servers connect with `/mcp` or `/mcps` (if not connected, verify the BASETEN_MCP_KEY in the harness config file).
+Check if the MCP servers connect with `/mcp` or `/mcps` (if not connected, verify the BASETEN_MCP_KEY in the harness 
+config file).
 
-You can start asking any questions or tasks related to Baseten, from chatting about the docs to brainstorming solution approaches, deploying and iterating on models, or managing your
-workspace. Most agents trigger the skill as needed automatically; alternatively you can invoke it with `/baseten`.
+You can start asking any questions or tasks related to Baseten, from chatting about the docs, to brainstorming 
+solution approaches, deploying and iterating on models or managing your workspace. Most agents trigger the skill as 
+needed automatically; alternatively you can invoke it with `/baseten`.

--- a/skills/baseten/SKILL.md
+++ b/skills/baseten/SKILL.md
@@ -2,8 +2,8 @@
 name: baseten
 description: >-
   Load for any work involving Baseten - deploying/operating models on Dedicated Inference (Truss, custom 
-  Docker servers, TRT-LLM engines, Chains), calling hosted Model APIs, running Training jobs (SFT/RL/LoRA),
-  or Model Frontier Gateway.
+  Docker servers, TRT-LLM engines, Chains), calling hosted Model APIs, running Training jobs (SFT/RL/LoRA), or Model
+  Frontier Gateway.
 ---
 
 ## Baseten Product Overview
@@ -20,28 +20,29 @@ cross-cloud HA, and seamless developer workflows.
 
 ## Agent DX Toolkit
 
-| Component | Provides                                                                                                             | Install |
-| --- |----------------------------------------------------------------------------------------------------------------------| --- |
+| Component | Provides | Install |
+| --- | --- | --- |
 | `baseten` MCP | Interact with backend (~REST API, CRUD): models, deployments, training, environments, secrets, chains. API-key auth. | `npx add-mcp https://api.baseten.co/mcp -g -y --header "Authorization: Bearer ${BASETEN_MCP_KEY}"` |
-| `baseten_docs` MCP | Keyword search of `docs.baseten.co`, grep. No auth.                                                                  | `npx add-mcp https://docs.baseten.co/mcp -n "baseten_docs" -g -y` |
-| `truss` CLI | Needed for model/chain push from local code, watch (= live patch). Needs `truss login` once.                         | `pip install truss --upgrade` (respect user package manager: uv, poetry...) |
-| `llms.txt` | `baseten.co/llms.txt` (product + blog), `docs.baseten.co/llms.txt` (docs).                                           | reachable via HTTP |
-| This skill | `SKILL.md` + `references/*.md` loaded on demand.                                                                     | `npx skills add basetenlabs/baseten-skills -g -y` |
+| `baseten_docs` MCP | Keyword search of `docs.baseten.co`, grep. No auth. | `npx add-mcp https://docs.baseten.co/mcp -n "baseten_docs" -g -y` |
+| `truss` CLI | Needed for model/chain push from local code, watch (= live patch). Needs `truss login` once. | `pip install truss --upgrade` (respect user package manager: uv, poetry...) |
+| `llms.txt` | `baseten.co/llms.txt` (product + blog), `docs.baseten.co/llms.txt` (docs). | reachable via HTTP |
+| This skill | `SKILL.md` + `references/*.md` loaded on demand. | `npx skills add basetenlabs/baseten-skills -g -y` |
 
 ### Setup
 
-- Any subset works, full install recommend.
-- Suggest additional installs when the current task benefits from or requires them; help user with installation, but 
+- Any subset works, full install recommended.
+- Suggest additional installs when the current task benefits from or requires them; help user with installation, but
   elicit preferences first.
 - Ensure `BASETEN_MCP_KEY` is provided when installing Baseten MCP (user can create key at
- `app.baseten.co/settings/api_keys`). Caveat: this binds the MCP to a specific org/workspace. Switching is not yet 
-  supported.
-- Truss CLI only needed for making deployments (check `truss --version`); prior login (multi-workspace users must 
+  `app.baseten.co/settings/api_keys`). Caveat: an MCP instance binds to one org/workspace at install time; switching the
+  bound workspace later is not supported. To work with multiple workspaces, install additional MCP instances under
+  different names with different keys (see last bullet of this section).
+- Truss CLI only needed for making deployments (check `truss --version`); prior login (multi-workspace users must
   provide `--remote <name>`). Explore with `truss [subcommand] --help`.
 - Docs MCP missing → grep / fetch `llms.txt`.
 - Backend MCP is API-key-only (currently); OAuth-only harnesses can still use the other components.
-- If backend MCP server is needed for different orgs/workspaces, add multiple MCP instances with different names/keys 
-  or use env-var expansion in the agent's config file and set the env var to the respective workspace's key.
+- If backend MCP server is needed for different orgs/workspaces, add multiple MCP instances with different names/keys or
+  use env-var expansion in the agent's config file and set the env var to the respective workspace's key.
 
 ## Pick your authoring surface (for creating deployments)
 
@@ -52,17 +53,17 @@ Surfaces are stacked by opinion-strength, not just author convenience: **engines
 performance-tuned for one architecture and are the fastest path when they fit; **custom Docker servers** wrap mature
 inference servers (vLLM, SGLang, TGI, Triton, NIM); **Python Truss** is the escape hatch for arbitrary code in the
 request path; **Chains** add typed inter-step transport with built-in rate limiting, connection management, structured
-error propagation, and binary IO — features you'd otherwise rebuild around N raw Trusses. Python truss and chains share 
-live-patch iteration (`truss watch`), all types support per-replica autoscaling, scale-to-zero, and environments / 
+error propagation, and binary IO — features you'd otherwise rebuild around N raw Trusses. Python Truss and Chains share
+live-patch iteration (`truss watch`); all flavors support per-replica autoscaling, scale-to-zero, and environments /
 promotions.
 
-| You want…                                                                                                    | Flavor | Specialization | When NOT to pick                                                        |
-|--------------------------------------------------------------------------------------------------------------| --- | --- |-------------------------------------------------------------------------|
-| Hosted LLM, no deploy step                                                                                   | Model APIs | `model-apis.md` | model not in catalog; need custom hardware, requirements, stability...  |
-| LLM on an off-the-shelf server (vLLM / SGLang / TGI / Triton / NIM)                                          | Custom Docker server | `truss-custom-servers.md` | the server doesn't exist or you need Python in the request path         |
-| LLM/embedding via a Baseten engine (TRT-LLM / BEI / BIS-LLM); minimal config, no Python                      | Engine-only `config.yaml` | `truss-config.md` (engines section) | architecture not covered by an engine; you need custom logic            |
-| Custom Python in the request path (pre/post, custom arch, weird IO)                                          | Python-class Truss (`model.py`) | `truss-model-py.md` + `truss-config.md` | an engine or off-the-shelf server fits — pick that, it's faster to ship |
-| Multi-step pipeline with **heterogeneous hardware / per-step scaling** (RAG, ASR→LLM→TTS, fan-out, chunking) | Chains | `truss-chains.md` | one-stage or homogeneous — a single Truss is simpler                    |
+| You want… | Flavor | Specialization | When NOT to pick |
+| --- | --- | --- | --- |
+| Hosted LLM, no deploy step | Model APIs | `model-apis.md` | model not in catalog; need custom hardware, requirements, stability... |
+| LLM on an off-the-shelf server (vLLM / SGLang / TGI / Triton / NIM) | Custom Docker server | `truss-custom-servers.md` | the server doesn't exist or you need Python in the request path |
+| LLM/embedding via a Baseten engine (TRT-LLM / BEI / BIS-LLM); minimal config, no Python | Engine-only `config.yaml` | `truss-config.md` (engines section) | architecture not covered by an engine; you need custom logic |
+| Custom Python in the request path (pre/post, custom arch, weird IO) | Python-class Truss (`model.py`) | `truss-model-py.md` + `truss-config.md` | an engine or off-the-shelf server fits — pick that, it's faster to ship |
+| Multi-step pipeline with **heterogeneous hardware / per-step scaling** (RAG, ASR→LLM→TTS, fan-out, chunking) | Chains | `truss-chains.md` | one-stage or homogeneous — a single Truss is simpler |
 
 Orthogonal operational surfaces (independent of which flavor above):
 
@@ -75,14 +76,14 @@ Real-world nuances the table can't capture:
 
 - **Hybrids exist.** A `model.py` can wrap an engine for pre/post-processing; a Chain entrypoint can be a Python class
   while internal Chainlets use engines.
-- **Chain websockets are entrypoint-only.** Intra-chainlet calls only stream output, but bi-di usually not 
-  needed on those edges.
+- **Chain websockets are entrypoint-only.** Intra-chainlet calls only stream output, but bi-di usually not needed on
+  those edges.
 - **Engine performance vs flexibility.** TRT-LLM is the fastest path for many LLMs but its config surface is opaque.
   Worth the trade only when latency/throughput is a real constraint.
 
 ## Routing
 
-**Skill References** (`ls references/` in skill dir, complementary to hosted docs). Be generous to read any of the 
+**Skill References** (`ls references/` in skill dir, complementary to hosted docs). Be generous to read any of the
 included reference files as soon as the user touches on that topic.
 
 - `references/truss-cli.md`: `truss push` / `watch` / iterate. Most-used. Deep dive: `references/truss-config.md`.
@@ -114,9 +115,9 @@ Fabricating numbers from training-data priors burns user trust; logs are the sou
 
 ### Source heterogeneity & drift
 
-Content lives across systems that don't overlap cleanly and drift independently. No single source is 
-perfect/authoritative. For any non-trivial claim ("supported", perf numbers, recommended approach), **triangulate 
-across ≥2 sources**. Surface contradictions to the user; don't paper over.
+Content lives across systems that don't overlap cleanly and drift independently. No single source is
+perfect/authoritative. For any non-trivial claim ("supported", perf numbers, recommended approach), **triangulate across
+≥2 sources**. Surface contradictions to the user; don't paper over.
 
 | Source | Strength | Gap / quirk |
 | --- | --- | --- |
@@ -131,7 +132,7 @@ across ≥2 sources**. Surface contradictions to the user; don't paper over.
   to reach out to Baseten support.
 - Perf numbers found only in a blog → cite as blog claim.
 - Can't find something via docs MCP → fetch `baseten.co/llms.txt` or `docs.baseten.co/llms.txt` as index, then fetch the
-  page directly. Last resprt: websearch.
+  page directly. Last resort: web search.
 
 ### Non-obvious placements within `references/`
 
@@ -142,9 +143,9 @@ across ≥2 sources**. Surface contradictions to the user; don't paper over.
 
 ### Tool quirks
 
-- Fetch full doc pages via `https://docs.baseten.co/<path>.md` (not docs MCP). Mintlify MCP server has a bug for full 
+- Fetch full doc pages via `https://docs.baseten.co/<path>.md` (not docs MCP). Mintlify MCP server has a bug for full
   pages, ok to use for search, `rg` / `tree` / `find` and `cat`/`head`.
-- `baseten_docs` MCP search is lexical. "speech to text" can rank TTS above STT (because of "speech" hits). 
-  Verify result relevant, try other queries and blog posts if in results are weak.
+- `baseten_docs` MCP search is lexical. "speech to text" can rank TTS above STT (because of "speech" hits). Verify
+  result relevant, try other queries and blog posts if results are weak.
 - `list_library_models` have mostly no useful tags (e.g. modality). Filter by `display_name` / `hf_repo_id` substrings.
 - Blog content is not in the docs MCP. Fetch `baseten.co/llms.txt` and search for relevant posts.

--- a/skills/baseten/SKILL.md
+++ b/skills/baseten/SKILL.md
@@ -1,8 +1,9 @@
 ---
 name: baseten
 description: >-
-  Skill for anything Baseten - deploying/operating models on Dedicated Inference (Truss, custom Docker servers, TRT-LLM
-  engines, Chains), calling pre-hosted Model APIs, running Training jobs (SFT/RL/LoRA), or Model Frontier Gateway.
+  Load for any work involving Baseten - deploying/operating models on Dedicated Inference (Truss, custom 
+  Docker servers, TRT-LLM engines, Chains), calling hosted Model APIs, running Training jobs (SFT/RL/LoRA),
+  or Model Frontier Gateway.
 ---
 
 ## Baseten Product Overview
@@ -19,35 +20,70 @@ cross-cloud HA, and seamless developer workflows.
 
 ## Agent DX Toolkit
 
-| Component | Provides | Install |
-| --- | --- | --- |
-| `baseten` MCP | Backend (~REST API): models, deployments, training, environments, secrets, chains. API-key auth. | `npx add-mcp https://api.baseten.co/mcp -g -y --header "Authorization: Bearer ${BASETEN_MCP_KEY}"` |
-| `baseten_docs` MCP | Lexical/keyword search of `docs.baseten.co`. No auth. | `npx add-mcp https://docs.baseten.co/mcp -n "baseten_docs" -g -y` |
-| `truss` CLI | Needed for model/chain push from local code, watch (= live patch). Needs `truss login` once. | `pip install truss --upgrade` (respect user package manager: uv, poetry...) |
-| `llms.txt` | `baseten.co/llms.txt` (product + blog), `docs.baseten.co/llms.txt` (docs). | reachable via HTTP |
-| This skill | `SKILL.md` + `references/*.md` loaded on demand. | `npx skills add basetenlabs/baseten-skills -g -y` |
+| Component | Provides                                                                                                             | Install |
+| --- |----------------------------------------------------------------------------------------------------------------------| --- |
+| `baseten` MCP | Interact with backend (~REST API, CRUD): models, deployments, training, environments, secrets, chains. API-key auth. | `npx add-mcp https://api.baseten.co/mcp -g -y --header "Authorization: Bearer ${BASETEN_MCP_KEY}"` |
+| `baseten_docs` MCP | Keyword search of `docs.baseten.co`, grep. No auth.                                                                  | `npx add-mcp https://docs.baseten.co/mcp -n "baseten_docs" -g -y` |
+| `truss` CLI | Needed for model/chain push from local code, watch (= live patch). Needs `truss login` once.                         | `pip install truss --upgrade` (respect user package manager: uv, poetry...) |
+| `llms.txt` | `baseten.co/llms.txt` (product + blog), `docs.baseten.co/llms.txt` (docs).                                           | reachable via HTTP |
+| This skill | `SKILL.md` + `references/*.md` loaded on demand.                                                                     | `npx skills add basetenlabs/baseten-skills -g -y` |
 
 ### Setup
 
-- Any subset works, the more the better.
-- Suggest additional installs when the current task benefits from them; help user run command, but elicit preferences
-  first.
-- Make sure `BASETEN_MCP_KEY` is set/provided when installing Baseten MCP (user can create new key at
-  `app.baseten.co/settings/api_keys`). Caveat: this binds the MCP to an org/workspace.
-- If backend MCP server is needed for different workspaces, add multiple MCP instances with different names/keys or use
-  env-var expansion in the agent's config file and set the env var to the respective workspace's key.
-- CLI via `truss --version`; prior login (multi-workspace users must provide `--remote <name>`).
+- Any subset works, full install recommend.
+- Suggest additional installs when the current task benefits from or requires them; help user with installation, but 
+  elicit preferences first.
+- Ensure `BASETEN_MCP_KEY` is provided when installing Baseten MCP (user can create key at
+ `app.baseten.co/settings/api_keys`). Caveat: this binds the MCP to a specific org/workspace. Switching is not yet 
+  supported.
+- Truss CLI only needed for making deployments (check `truss --version`); prior login (multi-workspace users must 
+  provide `--remote <name>`). Explore with `truss [subcommand] --help`.
 - Docs MCP missing → grep / fetch `llms.txt`.
 - Backend MCP is API-key-only (currently); OAuth-only harnesses can still use the other components.
+- If backend MCP server is needed for different orgs/workspaces, add multiple MCP instances with different names/keys 
+  or use env-var expansion in the agent's config file and set the env var to the respective workspace's key.
+
+## Pick your authoring surface (for creating deployments)
+
+First-pass decision. Many real workloads blend rows — treat this as a starting point, not a rule. When unsure, sketch
+the IO shape and per-step hardware needs before picking.
+
+Surfaces are stacked by opinion-strength, not just author convenience: **engines** (TRT-LLM, BEI, BIS-LLM) ship
+performance-tuned for one architecture and are the fastest path when they fit; **custom Docker servers** wrap mature
+inference servers (vLLM, SGLang, TGI, Triton, NIM); **Python Truss** is the escape hatch for arbitrary code in the
+request path; **Chains** add typed inter-step transport with built-in rate limiting, connection management, structured
+error propagation, and binary IO — features you'd otherwise rebuild around N raw Trusses. Python truss and chains share 
+live-patch iteration (`truss watch`), all types support per-replica autoscaling, scale-to-zero, and environments / 
+promotions.
+
+| You want…                                                                                                    | Flavor | Specialization | When NOT to pick                                                        |
+|--------------------------------------------------------------------------------------------------------------| --- | --- |-------------------------------------------------------------------------|
+| Hosted LLM, no deploy step                                                                                   | Model APIs | `model-apis.md` | model not in catalog; need custom hardware, requirements, stability...  |
+| LLM on an off-the-shelf server (vLLM / SGLang / TGI / Triton / NIM)                                          | Custom Docker server | `truss-custom-servers.md` | the server doesn't exist or you need Python in the request path         |
+| LLM/embedding via a Baseten engine (TRT-LLM / BEI / BIS-LLM); minimal config, no Python                      | Engine-only `config.yaml` | `truss-config.md` (engines section) | architecture not covered by an engine; you need custom logic            |
+| Custom Python in the request path (pre/post, custom arch, weird IO)                                          | Python-class Truss (`model.py`) | `truss-model-py.md` + `truss-config.md` | an engine or off-the-shelf server fits — pick that, it's faster to ship |
+| Multi-step pipeline with **heterogeneous hardware / per-step scaling** (RAG, ASR→LLM→TTS, fan-out, chunking) | Chains | `truss-chains.md` | one-stage or homogeneous — a single Truss is simpler                    |
+
+Orthogonal operational surfaces (independent of which flavor above):
+
+- Iterate / patch a deployment → `model-dev-loop.md`
+- Promote, environments, autoscaling → `deployment-lifecycle.md`
+- Call a deployment → `inference-api.md` (custom) or `model-apis.md` (hosted)
+- Programmatic control plane → `management-api.md`
+
+Real-world nuances the table can't capture:
+
+- **Hybrids exist.** A `model.py` can wrap an engine for pre/post-processing; a Chain entrypoint can be a Python class
+  while internal Chainlets use engines.
+- **Chain websockets are entrypoint-only.** Intra-chainlet calls only stream output, but bi-di usually not 
+  needed on those edges.
+- **Engine performance vs flexibility.** TRT-LLM is the fastest path for many LLMs but its config surface is opaque.
+  Worth the trade only when latency/throughput is a real constraint.
 
 ## Routing
 
-**Backend / local ops:**
-
-- `baseten` MCP: interact with backend, list, manage, observe.
-- `truss` CLI: push models/chains from local files / watch (~ live patch). `truss [subcommand] --help`.
-
-**Skill References** (`ls references/` in skill dir, complementary to hosted docs):
+**Skill References** (`ls references/` in skill dir, complementary to hosted docs). Be generous to read any of the 
+included reference files as soon as the user touches on that topic.
 
 - `references/truss-cli.md`: `truss push` / `watch` / iterate. Most-used. Deep dive: `references/truss-config.md`.
 - `references/truss-model-py.md`: Python-class flavor (custom pre/post, non-engine architectures).
@@ -65,11 +101,22 @@ cross-cloud HA, and seamless developer workflows.
 
 ## Gotchas
 
+### Don't speculate, query
+
+For any perf/status/error claim, **use the tools first** — don't estimate or guess.
+
+- Timings → deployment / chainlet log tools (timestamped, includes `Pulling image`, `model_cache: Fetch took`,
+  `Completed model.load() execution in N ms`, per-request markers).
+- Status → deployment-get tools before invoking.
+- Build/deploy failure → fetch logs **immediately**, don't hypothesize.
+
+Fabricating numbers from training-data priors burns user trust; logs are the source of truth.
+
 ### Source heterogeneity & drift
 
-Content lives across systems that don't overlap cleanly and drift independently. No single source is authoritative; for
-any non-trivial claim ("supported", perf numbers, recommended approach), **triangulate across ≥2 sources**. Surface
-contradictions to the user; don't paper over.
+Content lives across systems that don't overlap cleanly and drift independently. No single source is 
+perfect/authoritative. For any non-trivial claim ("supported", perf numbers, recommended approach), **triangulate 
+across ≥2 sources**. Surface contradictions to the user; don't paper over.
 
 | Source | Strength | Gap / quirk |
 | --- | --- | --- |
@@ -83,9 +130,8 @@ contradictions to the user; don't paper over.
 - Library page exists but model absent from `list_library_models` → likely managed/flagship; tell the user it may need
   to reach out to Baseten support.
 - Perf numbers found only in a blog → cite as blog claim.
-- Two sources disagree: try to determine which is newer/more accurate, otherwise flag uncertainty, let user decide.
 - Can't find something via docs MCP → fetch `baseten.co/llms.txt` or `docs.baseten.co/llms.txt` as index, then fetch the
-  page directly.
+  page directly. Last resprt: websearch.
 
 ### Non-obvious placements within `references/`
 
@@ -96,13 +142,9 @@ contradictions to the user; don't paper over.
 
 ### Tool quirks
 
-- **Full doc pages: `curl https://docs.baseten.co/<path>.md`, not the docs MCP.** Any docs page is served as rendered
-  markdown at that URL (no auth). Faster, ~half the bytes, bug-free. The docs MCP `cat`/`head` on certain `.mdx`
-  **inflates content quadratically**. Use the MCP filesystem tool only for `rg` / `tree` / `find` discovery when you
-  don't know the path.
-- **`baseten_docs` MCP search is lexical.** "speech to text" can rank TTS above STT (because of "speech" hits). Be
-  cautious.
-- **`list_library_models` tags are sparse** (mostly empty or `openai-compatible`); no modality tags. Filter by
-  `display_name` / `hf_repo_id` substrings.
-- **Blog content is not in the docs MCP.** Fetch `baseten.co/llms.txt` to enumerate blog URLs by topic, then `WebFetch`
-  the post.
+- Fetch full doc pages via `https://docs.baseten.co/<path>.md` (not docs MCP). Mintlify MCP server has a bug for full 
+  pages, ok to use for search, `rg` / `tree` / `find` and `cat`/`head`.
+- `baseten_docs` MCP search is lexical. "speech to text" can rank TTS above STT (because of "speech" hits). 
+  Verify result relevant, try other queries and blog posts if in results are weak.
+- `list_library_models` have mostly no useful tags (e.g. modality). Filter by `display_name` / `hf_repo_id` substrings.
+- Blog content is not in the docs MCP. Fetch `baseten.co/llms.txt` and search for relevant posts.

--- a/skills/baseten/references/inference-api.md
+++ b/skills/baseten/references/inference-api.md
@@ -7,6 +7,9 @@ deployments**: models and chains the user packaged with Truss and deployed to th
 - OpenAPI spec (authoritative): <https://api.baseten.co/inference-spec>
 - Reference overview: <https://docs.baseten.co/reference/inference-api/overview>
 
+**Prerequisites:** `deployment-lifecycle.md` (deployments, environments, dev vs published — route paths reflect these
+concepts).
+
 ## Authentication
 
 Every request sends an `Authorization: Api-Key $BASETEN_API_KEY` header. API keys are created at

--- a/skills/baseten/references/inference-api.md
+++ b/skills/baseten/references/inference-api.md
@@ -13,7 +13,7 @@ concepts).
 ## Authentication
 
 Every request sends an `Authorization: Api-Key $BASETEN_API_KEY` header. API keys are created at
-<https://app.baseten.co/settings/account/api_keys>.
+<https://app.baseten.co/settings/api_keys>.
 
 ## Endpoint URL shape
 

--- a/skills/baseten/references/management-api.md
+++ b/skills/baseten/references/management-api.md
@@ -18,8 +18,8 @@ Every request needs an API key in the `Authorization` header:
 Authorization: Api-Key $BASETEN_API_KEY
 ```
 
-API keys are created at <https://app.baseten.co/settings/account/api_keys> (user keys) or programmatically via the API
-Key endpoints.
+API keys are created at <https://app.baseten.co/settings/api_keys> (user keys) or programmatically via the API Key
+endpoints.
 
 ## Resource shape at a glance
 

--- a/skills/baseten/references/model-apis.md
+++ b/skills/baseten/references/model-apis.md
@@ -22,8 +22,8 @@ Authorization: Bearer $BASETEN_API_KEY
 
 `Bearer` is what the OpenAI SDK sets and what the docs prescribe for MAPI — use it.
 
-API keys are created at <https://app.baseten.co/settings/account/api_keys>. Inference-scoped keys are sufficient for
-MAPI calls (don't grant management scope for end-user inference clients).
+API keys are created at <https://app.baseten.co/settings/api_keys>. Inference-scoped keys are sufficient for MAPI calls
+(don't grant management scope for end-user inference clients).
 
 Model APIs require the specific model to be **enabled** in the workspace from <https://app.baseten.co/model-apis/create>
 before it can be called. A 404 on the model slug usually means the model is valid but not enabled in this workspace.
@@ -94,7 +94,7 @@ Current per-model support matrix is at <https://docs.baseten.co/inference/model-
 
 ```
 curl https://inference.baseten.co/v1/models \
-  -H "Authorization: Api-Key $BASETEN_API_KEY"
+  -H "Authorization: Bearer $BASETEN_API_KEY"
 ```
 
 Returns current slugs with metadata (context lengths, pricing, features).

--- a/skills/baseten/references/model-apis.md
+++ b/skills/baseten/references/model-apis.md
@@ -17,10 +17,13 @@ https://inference.baseten.co/v1
 Header on every request:
 
 ```
-Authorization: Api-Key $BASETEN_API_KEY
+Authorization: Bearer $BASETEN_API_KEY
 ```
 
-API keys are created at <https://app.baseten.co/settings/account/api_keys>.
+`Bearer` is what the OpenAI SDK sets and what the docs prescribe for MAPI — use it.
+
+API keys are created at <https://app.baseten.co/settings/account/api_keys>. Inference-scoped keys are sufficient for
+MAPI calls (don't grant management scope for end-user inference clients).
 
 Model APIs require the specific model to be **enabled** in the workspace from <https://app.baseten.co/model-apis/create>
 before it can be called. A 404 on the model slug usually means the model is valid but not enabled in this workspace.
@@ -120,8 +123,9 @@ Standard HTTP:
 - **The base URL differs from custom deployments.** Model APIs live at `inference.baseten.co`; custom deployments live
   at `model-{id}.api.baseten.co`. Swapping one for the other will fail.
 - **The `model=` field is meaningful here.** It picks the model. (On custom deployments it is a placeholder.)
-- **Auth header is `Authorization: Api-Key <key>`, not `Bearer <key>`.** OpenAI SDK handles this automatically;
-  hand-rolled HTTP must use the `Api-Key` prefix.
+- **Auth scheme differs by endpoint.** MAPI (OpenAI-compatible, this file) uses `Authorization: Bearer …`.
+  Custom-deployment endpoints (`model-{id}.api.baseten.co`, see `inference-api.md`) use `Authorization: Api-Key …`.
+  Don't generalize one to the other.
 - **Prefix caching is on by default.** Requests sharing a prefix with a recent request will see cache behavior; see the
   pricing docs for how that maps to billing.
 

--- a/skills/baseten/references/model-dev-loop.md
+++ b/skills/baseten/references/model-dev-loop.md
@@ -24,12 +24,12 @@ Chains have tiers 1 and 2 only; no hot-reload.
 `--watch` was built for humans saving files in an IDE. An agent edits in discrete bursts and knows when it is ready to
 test. Truss has no one-shot `truss patch` verb — patches only happen as a side effect of `truss [chains] push --watch`.
 The robust pattern for an agent is **one watcher per edit**: start the watcher, wait for the patch marker, kill it,
-test. Each cycle is self-contained, no long-lived background process for the harness to lose track of, recovery from
-any mid-loop failure is trivial (re-edit, re-run).
+test. Each cycle is self-contained, no long-lived background process for the harness to lose track of, recovery from any
+mid-loop failure is trivial (re-edit, re-run).
 
 `--watch` always produces a **development deployment** — mutable, single replica, scales to zero when idle, no
-autoscaling, one per model. Live patching is only possible against this slot, never against a published deployment.
-See `deployment-lifecycle.md` for the full dev-vs-published distinction.
+autoscaling, one per model. Live patching is only possible against this slot, never against a published deployment. See
+`deployment-lifecycle.md` for the full dev-vs-published distinction.
 
 Per edit (adapt to your harness — Bash, Python job control, etc.):
 
@@ -41,9 +41,15 @@ truss chains push --watch --remote <name> chain.py > /tmp/watch.log 2>&1 &
 WATCH_PID=$!
 # Single Truss:  truss watch --remote <name> > /tmp/watch.log 2>&1 &
 
-# 3. Wait for the patch marker (see "Log markers" below for the alternatives).
-while sleep 2; do
-  grep -qE 'Patched Chainlet|Failed to patch|patched successfully' /tmp/watch.log && break
+# 3. Wait for a terminal patch marker (see "Log markers" below). Includes the
+#    "Nothing to do" no-op so a chainlet that diffs clean still terminates the
+#    loop. Hard timeout prevents infinite hang if the watcher silently stalls.
+deadline=$((SECONDS + 300))
+while [ $SECONDS -lt $deadline ]; do
+  grep -qE \
+    'Patched Chainlet|Failed to patch|patched successfully|Nothing to do for Chainlet' \
+    /tmp/watch.log && break
+  sleep 2
 done
 
 # 4. Kill the watcher; the next edit gets a fresh one.
@@ -74,8 +80,8 @@ Trading that for the robustness of stateless cycles is worth it.
 
 ### When to drop the watcher
 
-The watcher cannot rebuild the image. If your change touches one of the unpatchable keys
-(`python_version`, `resources`, `live_reload`), or if the log shows `Patching is not supported for: <key>` /
+The watcher cannot rebuild the image. If your change touches one of the unpatchable keys (`python_version`, `resources`,
+`live_reload`), or if the log shows `Patching is not supported for: <key>` /
 `Failed to calculate patch. Change type might not be supported.`: do a one-shot plain `truss [chains] push` (no
 `--watch`, exits when upload completes), poll deployment status until `ACTIVE`, then resume the one-shot watcher recipe.
 Don't enumerate every "is this patchable?" up front — try the patch, fall back on the warning.
@@ -88,7 +94,7 @@ patched-on-top-of-patched dev state. Then promote to the target environment.
 ## Gotchas
 
 - **Watch keeps the dev deployment warm** — no scale-to-zero while watching. Stop it when not iterating.
-- **Atomic edits**: file writes that rename-into-place are seen by the watcher as one FS event. Bursts may collapse
-  into one patch — usually fine; if it matters, wait for the marker between edits.
+- **Atomic edits**: file writes that rename-into-place are seen by the watcher as one FS event. Bursts may collapse into
+  one patch — usually fine; if it matters, wait for the marker between edits.
 - **Multi-remote setups** require `--remote <name>`. If `truss push` errors with "Multiple remotes available," check
   `~/.trussrc`.

--- a/skills/baseten/references/model-dev-loop.md
+++ b/skills/baseten/references/model-dev-loop.md
@@ -1,112 +1,94 @@
 # Iterating on a deployment
 
-How to evolve a Truss model or Chain after the first deploy. Covers `truss push` vs `--watch` vs `--watch-hot-reload`,
-when each is admissible, and how the agent loop differs from the human watch loop the CLI was originally designed for.
+Agent-flavored notes for post-first-deploy iteration on a Truss model or Chain. Conceptual model and feature reference
+live in the docs — this file covers what the docs don't: the agent-specific watcher recipe and exact log markers.
 
-For flag-level reference see `truss-cli.md` (Trusses) and `truss-chains.md` (Chains). This file is the workflow layer
-above those.
+**Prerequisites:** `deployment-lifecycle.md` (especially dev vs published — `--watch` only patches a dev deployment);
+`truss-cli.md` (flag reference for `truss push` / `truss watch`); `truss-chains.md` if iterating on a Chain.
 
-## The three cost tiers
+Docs: <https://docs.baseten.co/development/model/deploy-and-iterate> (general),
+<https://docs.baseten.co/development/chain/localdev> (Chains local dev).
 
-Every change to a Truss/Chain falls into one of three tiers. Pick the cheapest valid tier for the change.
+## Three cost tiers — pick the cheapest valid one
 
-| Tier | What runs | Wall time (typical) | Triggered by |
+| Tier | What runs | Wall time | Triggered by |
 | --- | --- | --- | --- |
-| **Image rebuild** | Docker build, push, deploy, `load()` | minutes (3-10) | any `config.yaml` / `RemoteConfig` change: `system_packages`, `requirements`, `python_version`, `base_image`, `build_commands`, `docker_image`, `compute` |
-| **Live patch + reload** | File sync into container, server restart, `load()` re-runs | seconds (10-60) | any change to `model.py`, packages dir, or Chainlet `run_remote` / `__init__` |
-| **Hot-reload (Trusses only)** | In-process Model class swap; weights and caches preserved; `__init__` / `load` do **not** re-run | sub-second to ~2s | changes to `predict()` only, on a dev deployment started with `--watch-hot-reload` |
+| **Image rebuild** | Docker build + push + deploy + `load()` | minutes (3-10) | a small set of unpatchable config keys: `python_version`, `resources` (compute/instance type), `live_reload`. The watcher detects and refuses these — see "When to drop the watcher" below. |
+| **Live patch + reload** | File sync, server restart, `load()` re-runs | seconds (10-60) | everything else: `model.py` / Chainlet code, `requirements`, `system_packages`, env vars, `external_data`, `model_metadata`, `build_commands`, data dir, bundled packages |
+| **Hot-reload** (Trusses only) | In-process class swap; `__init__` / `load` do **not** re-run | sub-second to ~2s | `predict()`-only changes, dev deployment started with `--watch-hot-reload` |
 
-Chains have tiers 1 and 2 only. There is no hot-reload for Chainlets — `truss chains push --watch` does live patches;
-there is no equivalent of `--watch-hot-reload`.
+Chains have tiers 1 and 2 only; no hot-reload.
 
-## Robust baseline recipe
+## Watcher recipe for agents
 
-Conservative, always-correct, then refine for speed.
+`--watch` was built for humans saving files in an IDE. An agent edits in discrete bursts and knows when it is ready to
+test. Truss has no one-shot `truss patch` verb — patches only happen as a side effect of `truss [chains] push --watch`.
+The robust pattern for an agent is **one watcher per edit**: start the watcher, wait for the patch marker, kill it,
+test. Each cycle is self-contained, no long-lived background process for the harness to lose track of, recovery from
+any mid-loop failure is trivial (re-edit, re-run).
 
-1. **Bootstrap** — `truss push` (or `truss chains push`) once to a published deployment. Wait for ACTIVE. Establishes a
-   known-good image with current deps.
-2. **Debug loop** — start a development deployment with `--watch` (no hot-reload). Every edit to model code triggers
-   tier 2 (patch + `load()` re-run). Works for all model.py / Chainlet changes; never wrong.
-3. **Refinement (Trusses only)** — once iteration is narrowed to `predict()` logic and `load()` is expensive (LLMs,
-   large weights), restart the watcher with `--watch-hot-reload`. Drop a version sentinel in `predict()` (e.g.
-   `logger.info("predict v=2026-05-11.3")`) so each iteration confirms the swap took.
-4. **Dep change escape hatch** — if a change touches `config.yaml` / `RemoteConfig`, the watcher cannot help. Stop the
-   watcher, do a full `truss push`, restart the watcher when ACTIVE.
-5. **Publish** — final `truss push` (no `--watch`) so production is a clean cold start, not a patched-on-top-of-patched
-   in-memory state. Then promote to environment / production.
+`--watch` always produces a **development deployment** — mutable, single replica, scales to zero when idle, no
+autoscaling, one per model. Live patching is only possible against this slot, never against a published deployment.
+See `deployment-lifecycle.md` for the full dev-vs-published distinction.
 
-## Agent vs human loop
+Per edit (adapt to your harness — Bash, Python job control, etc.):
 
-The CLI's `--watch` was designed for a human editor: continuous FS watching is convenient when a person saves a file
-every few seconds in an IDE. An agent edits in discrete bursts and _knows_ when it is ready to test. Two implications:
+```bash
+# 1. Edit the file (atomic write — most editor/agent tools already do this).
 
-1. **Discrete patches would be cleaner than continuous watch.** Truss does not currently expose a one-shot `truss patch`
-   verb — patches happen only as a side effect of `truss watch` / `truss chains push --watch`. The available primitive
-   is "start the watcher, let your discrete edits flow through it, stop it when done."
-2. **The natural Claude Code shape** for the debug loop is:
-   - `Bash run_in_background` launches `truss watch --tail [--hot-reload]` (or `truss chains push --watch` with
-     `--include-git-info` etc.). Output redirected to a log file. One backgrounded process owns the watch.
-   - `Monitor` tails the log file with a grep filtered to terminal markers:
-     `"Completed model.load|patched|sync|Exception|Traceback|FAILED|Replica terminated"`. One notification per outcome —
-     keep filter alternation covering failures too (see Monitor coverage rule).
-   - Each `Edit` to model code → debounced FS event → watcher patches → Monitor fires with success or failure.
-   - `TaskStop` kills the watcher when debugging is done.
-3. **Edit atomicity matters.** The Edit tool writes atomically (write-temp + rename), so the watcher sees one coherent
-   event per Edit. Multiple Edits in quick succession may collapse into one patch (usually fine; if it matters, wait for
-   the Monitor event between edits).
+# 2. Start the watcher in the background, fresh log per cycle.
+truss chains push --watch --remote <name> chain.py > /tmp/watch.log 2>&1 &
+WATCH_PID=$!
+# Single Truss:  truss watch --remote <name> > /tmp/watch.log 2>&1 &
 
-## Hot-reload admissibility (Trusses only)
+# 3. Wait for the patch marker (see "Log markers" below for the alternatives).
+while sleep 2; do
+  grep -qE 'Patched Chainlet|Failed to patch|patched successfully' /tmp/watch.log && break
+done
 
-`--watch-hot-reload` swaps the **Model class** in-process without re-running `__init__` or `load`. Faster, but narrower
-applicability. Use it when **all** of these hold:
+# 4. Kill the watcher; the next edit gets a fresh one.
+kill "$WATCH_PID" 2>/dev/null
 
-- Only `predict()` (or methods called from it) changed.
-- No change to imports already resolved in the live process. Hot-reload swaps the class, not module globals —
-  re-imported modules may still bind to the old version.
-- No new state needs to be set up in `load()`. New tensors, file handles, opened sockets, downloaded files — none of
-  these will appear.
-- Not debugging cold-start behavior. Hot-reload defeats the purpose.
-- No stateful resources need teardown (GPU memory leaks, file handle exhaustion). The old class instance and any
-  references it owns persist until GC.
+# 5. Test the dev endpoint with a foreground call. On failure, fetch chainlet /
+#    deployment logs via the MCP / management API — don't guess.
+```
 
-When in doubt, drop `--watch-hot-reload`. Tier 2 (patch + reload) is 10-60s — annoying, not catastrophic.
+The watcher's ~5-15s of startup per cycle is in the noise next to the tier-2 patch wait (10-60s) and the test call.
+Trading that for the robustness of stateless cycles is worth it.
 
-**Version sentinel pattern.** Always include something like `logger.info(f"predict version={VERSION}")` and bump
-`VERSION` on each edit. Without it, a silent hot-reload no-op (e.g. due to module caching) is indistinguishable from a
-successful swap.
+### Log markers (from truss source)
 
-## Chains specifics
+| Surface | Success | No-op | Failure | Cycle done |
+| --- | --- | --- | --- | --- |
+| Chain | `✅ Patched Chainlet \`<name>\`.` | `💤 Nothing to do for Chainlet \`<name>\`.` | `❌ Failed to patch Chainlet \`<name>\`.` | `👀 Watching for new changes.` |
+| Truss | `Model <name> patched successfully.` | (silent skip) | `Failed to patch. ...` / `Patch failed: ...` | (rely on success/failure line) |
 
-- Chains use `truss chains push [--watch]` instead of `truss push`. Same tier-1 / tier-2 model; no tier 3.
-- `--experimental-watch-chainlets <name,...>` restricts patching to specific Chainlets — useful when one Chainlet has a
-  slow `load()` and you are iterating on another. Treat as experimental; not a substitute for stable workflow.
-- **Each Chainlet is independent** for rebuild purposes. Changing one Chainlet's `RemoteConfig` only rebuilds that
-  Chainlet's image. Use this to keep iteration cost down: stabilize heavy Chainlets first, then iterate on lighter ones.
-- **No rolling deployments for Chains.** A new published deploy is a hard cutover. Plan accordingly when promoting from
-  the dev-watch deployment to production.
-- **`Heavy-dependency imports inside Chainlet methods** (not module top) means the local watcher does not need GPU
-  libraries to run. Standard Chains idiom; keep doing it.
+### Useful flags
+
+- **`truss chains push --watch --experimental-watch-chainlets <Name1>,<Name2>`** — restrict patching to specific
+  Chainlets. Useful when iterating on a sibling of a heavy-`load()` Chainlet.
+- **`truss push --watch --watch-hot-reload`** (Trusses only) — swap the Model class in-process without re-running
+  `__init__`/`load`. Faster, but only valid when **all** of: only `predict()` changed; no new module-level imports; no
+  new state in `load()`; not debugging cold start. When unsure, drop the flag. Pair with a `VERSION` sentinel logged
+  from `predict()` so silent no-op swaps are detectable.
+
+### When to drop the watcher
+
+The watcher cannot rebuild the image. If your change touches one of the unpatchable keys
+(`python_version`, `resources`, `live_reload`), or if the log shows `Patching is not supported for: <key>` /
+`Failed to calculate patch. Change type might not be supported.`: do a one-shot plain `truss [chains] push` (no
+`--watch`, exits when upload completes), poll deployment status until `ACTIVE`, then resume the one-shot watcher recipe.
+Don't enumerate every "is this patchable?" up front — try the patch, fall back on the warning.
+
+## Publish step
+
+After iteration: do one clean `truss [chains] push` without `--watch` so production starts from a fresh image, not a
+patched-on-top-of-patched dev state. Then promote to the target environment.
 
 ## Gotchas
 
-- **Watch keeps the dev deployment warm** — no scale-to-zero while watching. Stop the watcher when not iterating, or
-  accept the cost.
-- **Watch breaks on `config.yaml` / `RemoteConfig` changes.** The watcher cannot perform a tier-1 rebuild. Stop it,
-  push, restart it.
-- **Hot-reload silently failing to apply.** The version-sentinel pattern is the only reliable defense — don't assume the
-  swap took.
-- **Final push before publish.** Production deploys should start from a clean image, not a watched dev deployment
-  patched 47 times. Always do a non-watch `truss push` as the publish step.
+- **Watch keeps the dev deployment warm** — no scale-to-zero while watching. Stop it when not iterating.
+- **Atomic edits**: file writes that rename-into-place are seen by the watcher as one FS event. Bursts may collapse
+  into one patch — usually fine; if it matters, wait for the marker between edits.
 - **Multi-remote setups** require `--remote <name>`. If `truss push` errors with "Multiple remotes available," check
   `~/.trussrc`.
-- **Cached truss credentials live in `~/.trussrc`.** Do not scrape it for the API key — set `BASETEN_API_KEY` explicitly
-  or ask the user.
-
-## Further reading
-
-- `truss-cli.md` — flag reference for `truss push` and `truss watch`.
-- `truss-chains.md` — Chainlet model and `truss chains push` reference.
-- Deploy-and-iterate guide: <https://docs.baseten.co/development/model/deploy-and-iterate>
-- Chains local development: <https://docs.baseten.co/development/chain/localdev> — `chains.run_local()` lets you iterate
-  Chainlet logic without a deploy at all; orthogonal to the watch loop but often the right first step for pure-Python
-  logic changes.

--- a/skills/baseten/references/truss-chains.md
+++ b/skills/baseten/references/truss-chains.md
@@ -103,12 +103,11 @@ Most of these you'd have to build (poorly) if you wired N Trusses together with 
 - **Binary IO helpers** — Chains can serialize numpy arrays as raw binary instead of base64'd JSON. Saves the ~33%
   base64 overhead on every payload edge (and that's before counting JSON's number-encoding bloat). See
   <https://docs.baseten.co/development/chain/binaryio>.
-- **Structured streaming** — helpers for end-to-end typed streams (`AsyncIterator[Model]`) across Chainlets, not just
-  at the entrypoint. See <https://docs.baseten.co/development/chain/streaming>.
+- **Structured streaming** — helpers for end-to-end typed streams (`AsyncIterator[Model]`) across Chainlets, not just at
+  the entrypoint. See <https://docs.baseten.co/development/chain/streaming>.
 - **Local testability** — `chains.run_local()` runs the whole graph in your process with mocked or real downstream
   Chainlets; you can swap any node for a stub or point it at a separately-deployed test deployment, and exercise the
-  orchestration logic without paying GPU costs. See
-  <https://docs.baseten.co/development/chain/localdev>.
+  orchestration logic without paying GPU costs. See <https://docs.baseten.co/development/chain/localdev>.
 - **Selective watch** — `truss chains push --watch --experimental-watch-chainlets <A>,<B>` patches only the named
   Chainlets, skipping `load()` on heavy siblings. Cuts inner-loop wall time when one Chainlet has slow startup.
 - **Per-Chainlet independence** — autoscaling, instance type, deps, and image rebuild scope are each per-Chainlet, so
@@ -174,12 +173,11 @@ For streaming, binary I/O, and websockets, see:
   image, not the local dev shell.
 - **A Chainlet hosts a real workload, not an HTTP wrapper.** If `run_remote` is essentially
   `await httpx.post(other_endpoint)`, collapse it into the caller — you're paying for a container + autoscaler +
-  cold-start budget to do zero work. Split into Chainlets only where hardware, dependencies, or scaling actually
-  differ.
-- **Batching vs unit-of-work is a tradeoff, not a default.** Calling `run_remote(items: list[T]) -> list[U]` once
-  beats N parallel calls **only when** the underlying model framework batches natively (e.g. diffusers, vLLM) **and**
-  replica count is small. With many autoscaling replicas at low `predict_concurrency`, small unit-of-work calls
-  spread across replicas often win. Measure both; don't assume.
+  cold-start budget to do zero work. Split into Chainlets only where hardware, dependencies, or scaling actually differ.
+- **Batching vs unit-of-work is a tradeoff, not a default.** Calling `run_remote(items: list[T]) -> list[U]` once beats
+  N parallel calls **only when** the underlying model framework batches natively (e.g. diffusers, vLLM) **and** replica
+  count is small. With many autoscaling replicas at low `predict_concurrency`, small unit-of-work calls spread across
+  replicas often win. Measure both; don't assume.
 
 ## Further reading
 

--- a/skills/baseten/references/truss-chains.md
+++ b/skills/baseten/references/truss-chains.md
@@ -8,6 +8,9 @@ or upscaling steps, retrieval into an LLM.
 Each step in a Chain is a **Chainlet**: a Python class that deploys independently on its own hardware with its own
 autoscaling policy. One Chainlet is marked as the **entrypoint** and handles the Chain's public HTTP surface.
 
+**Prerequisites:** `truss-config.md` (each Chainlet's `RemoteConfig` mirrors `config.yaml`); `deployment-lifecycle.md`
+(dev vs published, per-chainlet autoscaling, environments). For iteration: `truss-cli.md` + `model-dev-loop.md`.
+
 Reference docs live at <https://docs.baseten.co/development/chain/overview> and the CLI reference at
 <https://docs.baseten.co/reference/cli/chains/chains-cli>. For deeper patterns (streaming, binary I/O, error handling,
 subclassing), defer to the docs.
@@ -87,6 +90,32 @@ class PhiLLM(chains.ChainletBase):
 build time, same idea as the `model_cache` block in a classic Truss `config.yaml`. The full API surface is at
 <https://docs.baseten.co/reference/sdk/chains>.
 
+## What Chains gives you (beyond DIY orchestration)
+
+Most of these you'd have to build (poorly) if you wired N Trusses together with `httpx` by hand.
+
+- **Typed IO between Chainlets** — `run_remote` signatures use Pydantic / primitives; mismatches fail at deploy/import
+  time, not at first call in prod. Full IDE autocomplete on dependency calls.
+- **Generated client stubs (`BasetenSession`)** — created from your `chains.depends()` graph. You get rate limiting,
+  HTTP connection reuse + periodic rotation, retries, structured stack-trace propagation from a failing inner Chainlet
+  back to the caller (not "500 Internal Server Error" from a black box), and exported per-edge metrics — all without
+  writing the glue.
+- **Binary IO helpers** — Chains can serialize numpy arrays as raw binary instead of base64'd JSON. Saves the ~33%
+  base64 overhead on every payload edge (and that's before counting JSON's number-encoding bloat). See
+  <https://docs.baseten.co/development/chain/binaryio>.
+- **Structured streaming** — helpers for end-to-end typed streams (`AsyncIterator[Model]`) across Chainlets, not just
+  at the entrypoint. See <https://docs.baseten.co/development/chain/streaming>.
+- **Local testability** — `chains.run_local()` runs the whole graph in your process with mocked or real downstream
+  Chainlets; you can swap any node for a stub or point it at a separately-deployed test deployment, and exercise the
+  orchestration logic without paying GPU costs. See
+  <https://docs.baseten.co/development/chain/localdev>.
+- **Selective watch** — `truss chains push --watch --experimental-watch-chainlets <A>,<B>` patches only the named
+  Chainlets, skipping `load()` on heavy siblings. Cuts inner-loop wall time when one Chainlet has slow startup.
+- **Per-Chainlet independence** — autoscaling, instance type, deps, and image rebuild scope are each per-Chainlet, so
+  one slow node doesn't gate the rest.
+
+Broader context: <https://www.baseten.co/blog/baseten-chains-explained/>.
+
 ## Heavy-dependency imports
 
 Imports of Chainlet-specific packages (e.g. `torch`, `transformers`) commonly live **inside** `__init__` or `run_remote`
@@ -143,6 +172,14 @@ For streaming, binary I/O, and websockets, see:
 - **Local imports of heavy dependencies** (`torch`, `transformers`, etc.) inside `__init__` or `run_remote` are
   idiomatic for Chains even though they contradict the general "imports at top" rule - those libs live in the remote
   image, not the local dev shell.
+- **A Chainlet hosts a real workload, not an HTTP wrapper.** If `run_remote` is essentially
+  `await httpx.post(other_endpoint)`, collapse it into the caller — you're paying for a container + autoscaler +
+  cold-start budget to do zero work. Split into Chainlets only where hardware, dependencies, or scaling actually
+  differ.
+- **Batching vs unit-of-work is a tradeoff, not a default.** Calling `run_remote(items: list[T]) -> list[U]` once
+  beats N parallel calls **only when** the underlying model framework batches natively (e.g. diffusers, vLLM) **and**
+  replica count is small. With many autoscaling replicas at low `predict_concurrency`, small unit-of-work calls
+  spread across replicas often win. Measure both; don't assume.
 
 ## Further reading
 
@@ -155,3 +192,4 @@ For streaming, binary I/O, and websockets, see:
 - Local development: <https://docs.baseten.co/development/chain/localdev>
 - Example Chains (audio transcription, RAG): <https://docs.baseten.co/examples/chains-audio-transcription> and
   <https://docs.baseten.co/examples/chains-build-rag>
+- Blog (design rationale): <https://www.baseten.co/blog/baseten-chains-explained/>

--- a/skills/baseten/references/truss-cli.md
+++ b/skills/baseten/references/truss-cli.md
@@ -20,8 +20,8 @@ the user's preferred package manager.
 truss login
 ```
 
-Paste an API key from <https://app.baseten.co/settings/account/api_keys> when prompted. Truss stores credentials in
-`.trussrc` for future commands. In CI, set `BASETEN_API_KEY` and use `--remote` to select the saved remote name.
+Paste an API key from <https://app.baseten.co/settings/api_keys> when prompted. Truss stores credentials in `.trussrc`
+for future commands. In CI, set `BASETEN_API_KEY` and use `--remote` to select the saved remote name.
 
 ## `truss init` - scaffold
 
@@ -157,8 +157,8 @@ Workspace and account utilities. `whoami` prints the current authenticated user.
 - **`--watch-hot-reload` does not re-run `__init__` or `load`.** If your change relies on new state set up there, do a
   full reload (omit `--watch-hot-reload`) instead.
 - **`.trussrc` holds credentials.** Do not commit it. In CI / scripted flows, prefer `BASETEN_API_KEY` plus
-  `--remote <name>` over committing `.trussrc`. Truss is moving toward OS keyring storage; if asking for a key, ask
-  the user to export it as an env var rather than reading or writing credential files yourself.
+  `--remote <name>` over committing `.trussrc`. Truss is moving toward OS keyring storage; if asking for a key, ask the
+  user to export it as an env var rather than reading or writing credential files yourself.
 
 ## Further reading
 

--- a/skills/baseten/references/truss-cli.md
+++ b/skills/baseten/references/truss-cli.md
@@ -6,6 +6,9 @@ The `truss` CLI builds, deploys, and live-patches Trusses. The published referen
 This file covers Truss model commands only. For the `truss chains` subcommand group, see `truss-chains.md`. The
 `truss train` group (Truss Train) is not covered here; see <https://docs.baseten.co/reference/cli/training>.
 
+**Prerequisites:** `truss-config.md` (what's in `config.yaml`); `deployment-lifecycle.md` (default push is published,
+`--watch` makes a dev deployment — the distinction matters).
+
 ## Install
 
 `uv tool install truss` (or `uvx truss <command>` to run without installing); `pip install truss` also works. Respect
@@ -153,8 +156,9 @@ Workspace and account utilities. `whoami` prints the current authenticated user.
   Stop the watch (or accept the cost) accordingly.
 - **`--watch-hot-reload` does not re-run `__init__` or `load`.** If your change relies on new state set up there, do a
   full reload (omit `--watch-hot-reload`) instead.
-- **`.trussrc` holds credentials.** Do not commit it. In CI, prefer `BASETEN_API_KEY` plus `--remote <name>` over
-  committing `.trussrc`.
+- **`.trussrc` holds credentials.** Do not commit it. In CI / scripted flows, prefer `BASETEN_API_KEY` plus
+  `--remote <name>` over committing `.trussrc`. Truss is moving toward OS keyring storage; if asking for a key, ask
+  the user to export it as an env var rather than reading or writing credential files yourself.
 
 ## Further reading
 

--- a/skills/baseten/references/truss-config.md
+++ b/skills/baseten/references/truss-config.md
@@ -7,8 +7,8 @@ hardware, packages, secrets, and (for non-Python flavors) the Docker or engine c
 ## Authoring flavor — pick before writing config
 
 A `config.yaml` does not produce a working deployment on its own; it must be paired with an authoring flavor (Python
-class, custom Docker server, or engine-only). See the "Pick your authoring surface" table in `SKILL.md` for the
-decision tree.
+class, custom Docker server, or engine-only). See the "Pick your authoring surface" table in `SKILL.md` for the decision
+tree.
 
 The authoritative schema is the Pydantic-backed JSON schema in the Truss repo:
 
@@ -119,15 +119,18 @@ asked for fp16). Pin to the variant you actually load, e.g. for SDXL:
 ```yaml
 model_cache:
   - repo_id: stabilityai/stable-diffusion-xl-base-1.0
+    volume_folder: sdxl-base
+    use_volume: true
     allow_patterns: ["*.fp16.safetensors", "*.json", "*.txt"]
 ```
 
-Then in `model.py` / Chainlet code, point `from_pretrained` at the local cache path (skip HF-Hub snapshot lookup) and
-declare the variant explicitly:
+Weights land at `/app/model_cache/<volume_folder>/` inside the container (e.g. `/app/model_cache/sdxl-base/` above; if
+`volume_folder` is omitted Truss derives one from `repo_id` — list the directory at runtime to discover it). Point
+`from_pretrained` at that path (skips the HF-Hub snapshot lookup) and declare the variant explicitly:
 
 ```python
 StableDiffusionXLPipeline.from_pretrained(
-    "/app/model_cache/<volume_folder>",  # not the repo id — avoid HF Hub call
+    "/app/model_cache/sdxl-base",  # local cache path — not the repo id
     torch_dtype=torch.float16, variant="fp16", use_safetensors=True, low_cpu_mem_usage=True,
 )
 ```

--- a/skills/baseten/references/truss-config.md
+++ b/skills/baseten/references/truss-config.md
@@ -6,14 +6,9 @@ hardware, packages, secrets, and (for non-Python flavors) the Docker or engine c
 
 ## Authoring flavor — pick before writing config
 
-A `config.yaml` does not produce a working deployment on its own; it must be paired with one of three authoring flavors.
-Pick by the model, not by habit — `model.py` is the worst default for modern LLMs.
-
-| Flavor | When to pick | Reference |
-| --- | --- | --- |
-| **Python class** (`model.py` with `load` / `predict`) | Custom pre/post-processing, custom architecture, Python in the request path. | `truss-model-py.md` |
-| **Custom Docker server** (`docker_server` block — vLLM, TGI, SGLang, Triton, Ollama, NIM) | An off-the-shelf inference server already does it. Most common path for modern LLMs. | `truss-custom-servers.md` |
-| **Engine-only** (no code; `trt_llm` / BEI / BIS-LLM block in this file) | Standard architecture covered by a Baseten engine. Fastest path; no Python or Docker to maintain. | engines section below |
+A `config.yaml` does not produce a working deployment on its own; it must be paired with an authoring flavor (Python
+class, custom Docker server, or engine-only). See the "Pick your authoring surface" table in `SKILL.md` for the
+decision tree.
 
 The authoritative schema is the Pydantic-backed JSON schema in the Truss repo:
 
@@ -115,6 +110,27 @@ model_cache:
 
 The weights are baked into the image (or a layer) and available on disk when the container starts. Pair with a Hugging
 Face access secret if the repo is gated.
+
+**Multi-variant repos: narrow `allow_patterns`, set `variant` at load.** HF repos for many diffusion / vision models
+ship both fp32 and fp16 (sometimes bf16) copies of the same weights. A naive `allow_patterns: ["*.safetensors"]` pulls
+both — doubles disk and ~doubles `model.load()` time (the loader may pick the fp32 set and you pay for it even when you
+asked for fp16). Pin to the variant you actually load, e.g. for SDXL:
+
+```yaml
+model_cache:
+  - repo_id: stabilityai/stable-diffusion-xl-base-1.0
+    allow_patterns: ["*.fp16.safetensors", "*.json", "*.txt"]
+```
+
+Then in `model.py` / Chainlet code, point `from_pretrained` at the local cache path (skip HF-Hub snapshot lookup) and
+declare the variant explicitly:
+
+```python
+StableDiffusionXLPipeline.from_pretrained(
+    "/app/model_cache/<volume_folder>",  # not the repo id — avoid HF Hub call
+    torch_dtype=torch.float16, variant="fp16", use_safetensors=True, low_cpu_mem_usage=True,
+)
+```
 
 ## `docker_server` block (custom server flavor)
 

--- a/skills/baseten/references/truss-custom-servers.md
+++ b/skills/baseten/references/truss-custom-servers.md
@@ -7,6 +7,8 @@ the user needs; it is often the most popular path for modern LLM deployments.
 A custom-server Truss has no `model.py`. The `config.yaml` declares a `base_image` and a `docker_server` block; Truss
 builds (or, with `no_build`, ships verbatim) and Baseten runs the resulting image.
 
+**Prerequisites:** `truss-config.md` (the `docker_server` block lives there).
+
 ## The `docker_server` block
 
 ```yaml

--- a/skills/baseten/references/truss-model-py.md
+++ b/skills/baseten/references/truss-model-py.md
@@ -7,6 +7,8 @@ fit a ready-made HTTP server.
 If an off-the-shelf server (vLLM, TGI, SGLang, Triton) or a Baseten engine (TensorRT-LLM, BEI, BIS-LLM) does the job,
 prefer those instead. See `truss-custom-servers.md` and `truss-config.md` (engines section).
 
+**Prerequisites:** `truss-config.md` (the `model.py` flavor pairs with `config.yaml`).
+
 This skill covers the core contract. Sophisticated streaming patterns, custom batching, and performance tuning of the
 in-process server are intentionally out of scope; consult <https://docs.baseten.co/development/model> and the examples
 repo for those.


### PR DESCRIPTION
## Summary

Skill refinements from a long real-world session deploying a Storybook Chain (multi-modal, multi-chainlet). The lessons cluster around: where agents get misled, what's actually generalizable vs workspace-specific, and where the references blurred together.

### Top-level (`SKILL.md`)
- Added **"Pick your authoring surface"** decision section between Toolkit and Routing — table + framing of engines/custom-servers/Truss/Chains as a stack-by-opinion-strength, with explicit Chains-vs-DIY differentiators.
- Added **"Don't speculate, query"** Gotchas section — for any perf/status/error claim, use the log/get tools first.
- Slight enrichment of the Product Overview lead sentence.

### Auth & API correctness
- **`model-apis.md`**: standardized on `Bearer` for MAPI (matches docs and the OpenAI SDK), called out the `Api-Key` vs `Bearer` split between MAPI and custom-deployment endpoints. Companion docs PR: https://github.com/basetenlabs/docs.baseten.co/pull/784
- **`truss-cli.md`**: stronger guidance to prefer env-var prompting over reading/writing `~/.trussrc`; nod to upcoming keyring storage.

### Watcher recipe (`model-dev-loop.md`)
- **Single recipe** (one-shot per edit): start watcher → wait for marker → kill → test. No more "long-lived background watcher" pattern (caused real harness-bookkeeping issues mid-session).
- **Actual log markers** pulled from truss source (`✅ Patched Chainlet`, `❌ Failed to patch`, `Model X patched successfully`, etc.) — no more invented strings.
- **Accurate tier table**: only `python_version`, `resources`, `live_reload` require rebuild — `--watch` patches everything else (pip, system packages, env vars, build commands, model_cache, …). The previous claim "any config change ⇒ rebuild" was wrong.
- Trimmed from 150 → ~90 lines; signposts to docs for the bits docs already own.

### Chains pitch (`truss-chains.md`)
- Added **"What Chains gives you (beyond DIY orchestration)"** — typed IO, `BasetenSession` features (rate limiting, connection reuse, structured error propagation, per-edge metrics), binary IO for numpy (~33% savings vs base64), structured streaming, local testability via `chains.run_local()`, selective watch.
- Added two gotchas: **chainlet hosts a real workload, not an HTTP wrapper** (the "wrap each remote call in a CPU chainlet" anti-pattern I fell into for hours), and **batching is a measured tradeoff, not a default** (depends on framework + replica fanout).

### `model_cache` multi-variant pitfall (`truss-config.md`)
- New paragraph in the model_cache section: HF repos with fp16+fp32 variants (SDXL etc.) double disk + load time if `allow_patterns: ["*.safetensors"]` matches both. Pin to variant + pass `variant="fp16"` in `from_pretrained` + load from local cache path. Saved ~150s of `model.load()` in this session.

### Routing / prereqs
- Every reference now has a **Prerequisites:** line near the top declaring its conceptual deps (e.g. `model-dev-loop.md` needs `deployment-lifecycle.md` for dev/published, `truss-chains.md` needs `truss-config.md`).
- `truss-config.md`'s mini "Authoring flavor" table → 1-line pointer to SKILL.md (single source of truth).

## Test plan
- [ ] Skim `SKILL.md` — does the authoring-surface table make the decision tree clearer?
- [ ] Skim `model-dev-loop.md` — does the one-shot recipe match how you'd actually want an agent to iterate?
- [ ] Spot-check `truss-config.md` model_cache section + `truss-chains.md` "What Chains gives you" — accurate / non-overclaiming?
- [ ] Companion docs PR: https://github.com/basetenlabs/docs.baseten.co/pull/784