### PR TITLE
Document HTTP client connection reuse for Baseten callers

### DIFF
--- a/skills/baseten/SKILL.md
+++ b/skills/baseten/SKILL.md
@@ -93,7 +93,8 @@ included reference files as soon as the user touches on that topic.
 - `references/truss-chains.md`: multi-step pipelines (RAG, ASR→LLM→TTS, chunked audio/video) with per-step HW +
   autoscaling.
 - `references/model-apis.md`: shared pre-hosted endpoints (DeepSeek, GLM, Kimi, ...). Fastest when one fits.
-- `references/inference-api.md`: calling **custom** deployments. async / streaming / wake / OpenAI-compat sync routes.
+- `references/inference-api.md`: calling **custom** deployments. connection reuse (`requests` / `httpx` / OpenAI SDK),
+  async / streaming / wake / OpenAI-compat sync routes.
 - `references/management-api.md`: programmatic control plane (models, deployments, envs, secrets). What `truss` CLI uses
   under the hood.
 - `references/deployment-lifecycle.md`: Model / Deployment / Environment semantics + promotion + autoscaling.

--- a/skills/baseten/references/inference-api.md
+++ b/skills/baseten/references/inference-api.md
@@ -46,8 +46,8 @@ Reuse the same session for streaming (`session.post(..., stream=True)`).
 
 ### `httpx`
 
-Sync: one `httpx.Client` created at app startup, closed on shutdown. Async: one `httpx.AsyncClient` per event loop (or app
-lifespan). Set `headers` on the client so every call inherits `Authorization: Api-Key …`.
+Sync: one `httpx.Client` created at app startup, closed on shutdown. Async: one `httpx.AsyncClient` per event loop (or
+app lifespan). Set `headers` on the client so every call inherits `Authorization: Api-Key …`.
 
 ```python
 import os
@@ -266,9 +266,9 @@ for pre-warming right before a latency-sensitive workload.
   client bug.
 - **Failed webhook delivery after retries loses the result.** Log and persist on the webhook side before returning 200.
 - **Request timeouts are on your client.** Long `predict` calls need a client timeout large enough (or use async).
-- **Reuse HTTP clients for repeated calls.** One-off `requests.post()` or a new `OpenAI()` per request adds TLS/handshake
-  latency every time. Use `requests.Session`, a long-lived `httpx` client, or a process-scoped OpenAI client (see
-  Connection reuse).
+- **Reuse HTTP clients for repeated calls.** One-off `requests.post()` or a new `OpenAI()` per request adds
+  TLS/handshake latency every time. Use `requests.Session`, a long-lived `httpx` client, or a process-scoped OpenAI
+  client (see Connection reuse).
 - **Gates on `development` targets return 404 when the dev deployment has scaled to zero** between requests.
   `truss watch` keeps it warm; outside of `watch`, consider `/wake` or the scale-to-zero behavior.
 - **Custom server `sync` routing only works for routes the server actually exposes.** `predict_endpoint` is the shortcut

--- a/skills/baseten/references/inference-api.md
+++ b/skills/baseten/references/inference-api.md
@@ -15,6 +15,67 @@ concepts).
 Every request sends an `Authorization: Api-Key $BASETEN_API_KEY` header. API keys are created at
 <https://app.baseten.co/settings/api_keys>.
 
+## Connection reuse (low-latency clients)
+
+For workloads that call Baseten repeatedly (agents, RAG loops, batch drivers), **reuse one HTTP client per process**
+instead of opening a new TCP/TLS connection per request. A one-off `requests.post()` or a new `OpenAI()` per call pays
+TLS and HTTP setup on every round trip — often tens of milliseconds that add up when prompts are short or QPS is high.
+
+### `requests`
+
+Use a module- or app-scoped `requests.Session()` and set auth once on the session:
+
+```python
+import os
+import requests
+
+session = requests.Session()
+session.headers.update({"Authorization": f"Api-Key {os.environ['BASETEN_API_KEY']}"})
+
+def predict(payload: dict) -> dict:
+    response = session.post(
+        f"https://model-{os.environ['MODEL_ID']}.api.baseten.co/environments/production/predict",
+        json=payload,
+        timeout=60,
+    )
+    response.raise_for_status()
+    return response.json()
+```
+
+Reuse the same session for streaming (`session.post(..., stream=True)`).
+
+### `httpx`
+
+Sync: one `httpx.Client` created at app startup, closed on shutdown. Async: one `httpx.AsyncClient` per event loop (or app
+lifespan). Set `headers` on the client so every call inherits `Authorization: Api-Key …`.
+
+```python
+import httpx
+
+client = httpx.Client(
+    headers={"Authorization": f"Api-Key {api_key}"},
+    timeout=60.0,
+)
+# client.post(url, json=payload) for each call; client.aclose() / client.close() on shutdown
+```
+
+### OpenAI SDK
+
+The SDK uses `httpx` internally. **Construct one `OpenAI` (or `AsyncOpenAI`) client and reuse it** for all
+`chat.completions` calls — do not instantiate a new client per request. In web apps, register the client as a singleton
+or dependency-injected service; in scripts, create it at module scope.
+
+### When it matters most
+
+- High QPS or tight loops against the same `model-{id}` or `chain-{id}` host
+- Short prompts where network overhead is visible next to model time
+- `/wake` followed immediately by many predictions (reuse the same client for wake and predict)
+
+### Chains (internal)
+
+Chainlet-to-Chainlet calls use generated `BasetenSession` stubs with built-in connection reuse and rotation (see
+`truss-chains.md`). **External** callers to `predict` / `run_remote` must manage reuse themselves as above.
+
 ## Endpoint URL shape
 
 **Models:**
@@ -75,11 +136,11 @@ import os
 import requests
 
 model_id = os.environ["MODEL_ID"]
-api_key = os.environ["BASETEN_API_KEY"]
+session = requests.Session()
+session.headers.update({"Authorization": f"Api-Key {os.environ['BASETEN_API_KEY']}"})
 
-response = requests.post(
+response = session.post(
     f"https://model-{model_id}.api.baseten.co/environments/production/predict",
-    headers={"Authorization": f"Api-Key {api_key}"},
     json={"messages": [{"role": "user", "content": "Hello"}]},
     timeout=60,
 )
@@ -96,7 +157,8 @@ If the deployed model's `predict` returns a generator (or a custom server emits 
 HTTP stream. Read it incrementally:
 
 ```python
-with requests.post(url, headers=headers, json=payload, stream=True, timeout=60) as response:
+# session: requests.Session with Authorization header set once (see Connection reuse)
+with session.post(url, json=payload, stream=True, timeout=60) as response:
     response.raise_for_status()
     for chunk in response.iter_content(chunk_size=None):
         print(chunk.decode(), end="")
@@ -115,6 +177,7 @@ import os
 from openai import OpenAI
 
 model_id = os.environ["MODEL_ID"]
+# Reuse this client for all calls in the process (do not construct per request).
 client = OpenAI(
     base_url=f"https://model-{model_id}.api.baseten.co/environments/production/sync/v1",
     api_key=os.environ["BASETEN_API_KEY"],
@@ -202,6 +265,9 @@ for pre-warming right before a latency-sensitive workload.
   client bug.
 - **Failed webhook delivery after retries loses the result.** Log and persist on the webhook side before returning 200.
 - **Request timeouts are on your client.** Long `predict` calls need a client timeout large enough (or use async).
+- **Reuse HTTP clients for repeated calls.** One-off `requests.post()` or a new `OpenAI()` per request adds TLS/handshake
+  latency every time. Use `requests.Session`, a long-lived `httpx` client, or a process-scoped OpenAI client (see
+  Connection reuse).
 - **Gates on `development` targets return 404 when the dev deployment has scaled to zero** between requests.
   `truss watch` keeps it warm; outside of `watch`, consider `/wake` or the scale-to-zero behavior.
 - **Custom server `sync` routing only works for routes the server actually exposes.** `predict_endpoint` is the shortcut

--- a/skills/baseten/references/inference-api.md
+++ b/skills/baseten/references/inference-api.md
@@ -50,13 +50,14 @@ Sync: one `httpx.Client` created at app startup, closed on shutdown. Async: one 
 lifespan). Set `headers` on the client so every call inherits `Authorization: Api-Key …`.
 
 ```python
+import os
 import httpx
 
 client = httpx.Client(
-    headers={"Authorization": f"Api-Key {api_key}"},
+    headers={"Authorization": f"Api-Key {os.environ['BASETEN_API_KEY']}"},
     timeout=60.0,
 )
-# client.post(url, json=payload) for each call; client.aclose() / client.close() on shutdown
+# client.post(url, json=payload) for each call; client.close() on shutdown
 ```
 
 ### OpenAI SDK

--- a/skills/baseten/references/model-apis.md
+++ b/skills/baseten/references/model-apis.md
@@ -36,6 +36,7 @@ Use the official OpenAI SDK pointed at the Baseten base URL:
 import os
 from openai import OpenAI
 
+# Reuse this client for all calls in the process (do not construct per request).
 client = OpenAI(
     base_url="https://inference.baseten.co/v1",
     api_key=os.environ["BASETEN_API_KEY"],
@@ -53,6 +54,11 @@ print(response.choices[0].message.content)
 
 Substitute any enabled model slug for the `model=` argument. Unlike the custom-deployment sync endpoint (where `model=`
 is a placeholder), **on Model APIs the `model=` field actively selects which model serves the request** - get it right.
+
+Create the `OpenAI` client once per process (module scope, app singleton, or dependency injection) and reuse it for
+every `chat.completions.create` call. The SDK pools HTTP connections via `httpx` under the hood; constructing a new
+`OpenAI()` per request discards that pooling and adds TLS handshake latency on each call. For `requests` or `httpx`
+against custom deployments, see **Connection reuse** in `inference-api.md`.
 
 ## Streaming
 
@@ -128,6 +134,8 @@ Standard HTTP:
   Don't generalize one to the other.
 - **Prefix caching is on by default.** Requests sharing a prefix with a recent request will see cache behavior; see the
   pricing docs for how that maps to billing.
+- **Reuse the OpenAI client.** A new `OpenAI()` per request loses connection pooling; keep one client per process for
+  agents and high-QPS loops.
 
 ## Further reading
 


### PR DESCRIPTION
## Summary

- Add a **Connection reuse** section to `inference-api.md` covering `requests.Session`, long-lived `httpx` sync/async clients, and process-scoped `OpenAI` / `AsyncOpenAI` clients.
- Update minimal `predict` and streaming examples to use `requests.Session` instead of one-off `requests.post()`.
- Note in `model-apis.md` and `SKILL.md` that callers should reuse the OpenAI client for repeated Model API traffic.

## Test plan

- [x] Docs-only change; no eval re-run required for this PR (guidance addition, examples remain valid).
- [ ] Reviewer confirms examples match Baseten auth headers (`Api-Key` vs `Bearer`) per endpoint.


Made with [Cursor](https://cursor.com)