### PR TITLE
Skill polish: clearer list_library_models guidance + MCP-vs-invocation section

### DIFF
--- a/skills/baseten/SKILL.md
+++ b/skills/baseten/SKILL.md
@@ -147,25 +147,25 @@ perfect/authoritative. For any non-trivial claim ("supported", perf numbers, rec
   pages, ok to use for search, `rg` / `tree` / `find` and `cat`/`head`.
 - `baseten_docs` MCP search is lexical. "speech to text" can rank TTS above STT (because of "speech" hits). Verify
   result relevant, try other queries and blog posts if results are weak.
-- `list_library_models` is **baseten curated catalog** (~tens of pre-optimized hosted models, mostly popular 
-  open-source LLMs / embeddings). Models are good starter models to play, but not for custom authoring, 
-  specific performance needs, finetuning and private HF models etc. No useful tags (modality etc.) — filter by `display_name` / `hf_repo_id` substring.
+- `list_library_models` is **baseten curated catalog** (~tens of pre-optimized hosted models, mostly popular open-source
+  LLMs / embeddings). Models are good starter models to play, but not for custom authoring, specific performance needs,
+  finetuning and private HF models etc. No useful tags (modality etc.) — filter by `display_name` / `hf_repo_id`
+  substring.
 - Blog content is not in the docs MCP. Fetch `baseten.co/llms.txt` and search for relevant posts.
 
 ### MCP introspection vs. invocation
 
-Backend MCP tools (`get_deployment`, `get_deployment_logs`, `get_deployment_config`, `list_*`, …) describe
-state. They are strongest when you need an exact id / schema / config value to act on, and weakest when
-the user's complaint is about runtime behavior. Resist letting MCP availability shrink the size of your
-investigation.
+Backend MCP tools (`get_deployment`, `get_deployment_logs`, `get_deployment_config`, `list_*`, …) describe state. They
+are strongest when you need an exact id / schema / config value to act on, and weakest when the user's complaint is
+about runtime behavior. Resist letting MCP availability shrink the size of your investigation.
 
-- **Look-up tasks** (need an ID, current config, or schema before writing a patch): MCP get/list is the right
-  starting point. Reading the live config beats inferring it.
-- **Behavior tasks** (broken / slow / wrong-shape responses, anything the user *observed*): MCP can supplement
-  but rarely substitutes for exercising the endpoint yourself. A `curl` against the predict URL with a
-  representative payload runs the same code path the user does. Absence of recent errors in MCP-fetched logs
-  is not proof the bug is gone — log windows are bounded, and a problem the user reported five minutes ago
-  may have already aged out of the default tail. For a specific historic incident you can't reproduce, log
-  tools support custom time ranges within retention; use them.
-- Treat cheap introspection as budget freed up for deeper verification (re-curl after a fix, diff configs
-  before and after a PATCH, push a candidate truss and probe it), not as license to stop earlier.
+- **Look-up tasks** (need an ID, current config, or schema before writing a patch): MCP get/list is the right starting
+  point. Reading the live config beats inferring it.
+- **Behavior tasks** (broken / slow / wrong-shape responses, anything the user _observed_): MCP can supplement but
+  rarely substitutes for exercising the endpoint yourself. A `curl` against the predict URL with a representative
+  payload runs the same code path the user does. Absence of recent errors in MCP-fetched logs is not proof the bug is
+  gone — log windows are bounded, and a problem the user reported five minutes ago may have already aged out of the
+  default tail. For a specific historic incident you can't reproduce, log tools support custom time ranges within
+  retention; use them.
+- Treat cheap introspection as budget freed up for deeper verification (re-curl after a fix, diff configs before and
+  after a PATCH, push a candidate truss and probe it), not as license to stop earlier.

--- a/skills/baseten/SKILL.md
+++ b/skills/baseten/SKILL.md
@@ -147,5 +147,25 @@ perfect/authoritative. For any non-trivial claim ("supported", perf numbers, rec
   pages, ok to use for search, `rg` / `tree` / `find` and `cat`/`head`.
 - `baseten_docs` MCP search is lexical. "speech to text" can rank TTS above STT (because of "speech" hits). Verify
   result relevant, try other queries and blog posts if results are weak.
-- `list_library_models` have mostly no useful tags (e.g. modality). Filter by `display_name` / `hf_repo_id` substrings.
+- `list_library_models` is **baseten curated catalog** (~tens of pre-optimized hosted models, mostly popular 
+  open-source LLMs / embeddings). Models are good starter models to play, but not for custom authoring, 
+  specific performance needs, finetuning and private HF models etc. No useful tags (modality etc.) — filter by `display_name` / `hf_repo_id` substring.
 - Blog content is not in the docs MCP. Fetch `baseten.co/llms.txt` and search for relevant posts.
+
+### MCP introspection vs. invocation
+
+Backend MCP tools (`get_deployment`, `get_deployment_logs`, `get_deployment_config`, `list_*`, …) describe
+state. They are strongest when you need an exact id / schema / config value to act on, and weakest when
+the user's complaint is about runtime behavior. Resist letting MCP availability shrink the size of your
+investigation.
+
+- **Look-up tasks** (need an ID, current config, or schema before writing a patch): MCP get/list is the right
+  starting point. Reading the live config beats inferring it.
+- **Behavior tasks** (broken / slow / wrong-shape responses, anything the user *observed*): MCP can supplement
+  but rarely substitutes for exercising the endpoint yourself. A `curl` against the predict URL with a
+  representative payload runs the same code path the user does. Absence of recent errors in MCP-fetched logs
+  is not proof the bug is gone — log windows are bounded, and a problem the user reported five minutes ago
+  may have already aged out of the default tail. For a specific historic incident you can't reproduce, log
+  tools support custom time ranges within retention; use them.
+- Treat cheap introspection as budget freed up for deeper verification (re-curl after a fix, diff configs
+  before and after a PATCH, push a candidate truss and probe it), not as license to stop earlier.

--- a/skills/baseten/references/management-api.md
+++ b/skills/baseten/references/management-api.md
@@ -1,125 +1,46 @@
 # Baseten management API
 
-The management API is the programmatic control plane for models, deployments, environments, autoscaling, secrets, API
-keys, teams, and billing. Use it from scripts and CI when the truss CLI or the dashboard do not fit the workflow. The
-`truss` CLI itself uses this API under the hood for push and promotion operations.
+Programmatic control plane for models, deployments, environments, autoscaling, secrets, API keys, teams, and billing.
+The `truss` CLI uses this API under the hood for push and promotion operations.
 
 - Base URL: `https://api.baseten.co`
 - OpenAPI spec (authoritative): <https://api.baseten.co/v1/spec>
 - Reference docs (grouped by resource): <https://docs.baseten.co/reference/management-api/overview>
 
-Prefer generating a client from the OpenAPI spec for non-trivial integrations rather than hand-rolling HTTP calls.
+## How to call it
 
-## Authentication
+1. **`baseten` MCP** (preferred).
+2. If MCP not installed → in interactive sessions, offer install (SKILL.md "Agent DX Toolkit")
+3. Otherwise fall back **REST API**
+   Spec: <https://api.baseten.co/v1/spec>. Overview: <https://docs.baseten.co/reference/management-api/overview>.
+   Non-trivial integrations → generate from the spec.
 
-Every request needs an API key in the `Authorization` header:
+### Authentication
 
 ```
 Authorization: Api-Key $BASETEN_API_KEY
 ```
 
-API keys are created at <https://app.baseten.co/settings/api_keys> (user keys) or programmatically via the API Key
-endpoints.
+Keys: <https://app.baseten.co/settings/api_keys>.
 
-## Resource shape at a glance
+### Resource shape
 
-All paths are under `/v1`. The surface divides cleanly:
+All paths under `/v1`:
 
-- **Models**: `/v1/models`, `/v1/models/{model_id}` (list, get, delete).
-- **Chains**: `/v1/chains`, `/v1/chains/{chain_id}` (list, get, delete).
-- **Deployments** (per-model and per-chain): list, get, delete, activate, deactivate, retry, promote, terminate replica.
-- **Environments** (per-model and per-chain): create, list, get, update (autoscaling and settings).
-- **Autoscaling**: PATCH endpoints on each deployment / environment.
-- **Instance types**: `/v1/instance_types` (list), `/v1/instance_type_prices` (pricing).
-- **Secrets**: `/v1/secrets` (list, create/update), and `/v1/teams/{team_id}/secrets` for team-scoped secrets.
-- **API keys**: `/v1/api_keys` (list, create, delete), `/v1/teams/{team_id}/api_keys`.
-- **Teams**: `/v1/teams` (list).
-- **Billing**: `/v1/billing/usage_summary`.
-- **Training**: `/v1/training_projects/...` (training jobs and checkpoints). Out of scope for this skill; see
-  <https://docs.baseten.co/reference/training-api>.
+- **Models** / **Chains**: list, get, delete.
+- **Deployments**: list, get, delete, activate, deactivate, retry, promote, terminate replica.
+- **Environments**: create, list, get, update (autoscaling, settings). Rolling deployment controls
+  (`pause_promotion`, `resume_promotion`, `force_*`, `cancel_promotion`) live on the environment path.
+- **Autoscaling**: PATCH on deployment / environment.
+- **Instance types**: `/v1/instance_types`, `/v1/instance_type_prices` — authoritative valid-resources list for
+  `config.yaml`.
+- **Secrets**: `/v1/secrets` (workspace), `/v1/teams/{team_id}/secrets` (team-scoped). Upsert by name.
+- **API keys**, **Teams**, **Billing** (`/v1/billing/usage_summary`), **Training** (`/v1/training_projects/...` — out of
+  scope for this skill, see <https://docs.baseten.co/reference/training-api>).
 
-The full endpoint table with per-endpoint links is at <https://docs.baseten.co/reference/management-api/overview>.
+Full endpoint table: <https://docs.baseten.co/reference/management-api/overview>.
 
-## Common patterns
-
-### List all deployments of a model
-
-```bash
-curl -H "Authorization: Api-Key $BASETEN_API_KEY" \
-  https://api.baseten.co/v1/models/$MODEL_ID/deployments
-```
-
-### Promote a deployment into an environment
-
-```bash
-curl -X POST \
-  -H "Authorization: Api-Key $BASETEN_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"deployment_id": "$DEPLOYMENT_ID"}' \
-  https://api.baseten.co/v1/models/$MODEL_ID/environments/production/promote
-```
-
-Related rolling-deployment controls on the same `environments/{env_name}` path: `pause_promotion`, `resume_promotion`,
-`force_cancel_promotion`, `force_roll_forward_promotion`, `cancel_promotion`.
-
-### Update autoscaling on production
-
-```bash
-curl -X PATCH \
-  -H "Authorization: Api-Key $BASETEN_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"min_replicas": 1, "max_replicas": 10, "concurrency_target": 1}' \
-  https://api.baseten.co/v1/models/$MODEL_ID/deployments/production/autoscaling_settings
-```
-
-Development, production, and arbitrary deployment IDs each have their own PATCH endpoints; see the overview reference.
-
-### Activate or deactivate
-
-```bash
-curl -X POST \
-  -H "Authorization: Api-Key $BASETEN_API_KEY" \
-  https://api.baseten.co/v1/models/$MODEL_ID/deployments/$DEPLOYMENT_ID/deactivate
-```
-
-Deactivation suspends serving (API returns 404) without deleting the deployment; reactivate with the matching
-`/activate` endpoint.
-
-### Manage secrets
-
-```bash
-# Create or update a workspace secret (idempotent upsert).
-curl -X POST \
-  -H "Authorization: Api-Key $BASETEN_API_KEY" \
-  -H "Content-Type: application/json" \
-  -d '{"name": "HF_ACCESS_TOKEN", "value": "hf_..."}' \
-  https://api.baseten.co/v1/secrets
-```
-
-Team-scoped secrets live under `/v1/teams/{team_id}/secrets` with the same shape.
-
-### List instance types (valid resources)
-
-```bash
-curl -H "Authorization: Api-Key $BASETEN_API_KEY" \
-  https://api.baseten.co/v1/instance_types
-```
-
-Useful when `config.yaml`'s `instance_type` field is unclear; the returned list is the authoritative set of valid values
-for the workspace.
-
-## Chains
-
-Chain management mirrors models with `/v1/chains/...` in place of `/v1/models/...`. Notable differences:
-
-- Chain deployments have a combined environment update endpoint for chainlet settings (instance types, autoscaling).
-- Rolling deployments are **not supported for Chains**; promotion is an immediate traffic swap.
-
-See the Chains tab in the overview reference for the full endpoint set.
-
-## Python usage
-
-Plain `requests` is fine:
+### Python (for user-facing code)
 
 ```python
 import os
@@ -140,24 +61,29 @@ def list_deployments(model_id: str) -> list[dict]:
     return response.json()
 ```
 
-For anything non-trivial, generate a client from <https://api.baseten.co/v1/spec> rather than hand-rolling more methods.
-The spec is authoritative and moves faster than prose docs.
+For anything non-trivial, generate the client from <https://api.baseten.co/v1/spec>.
+
+## Chains differences
+
+Chain management mirrors models with `/v1/chains/...`. Notable:
+
+- Chain deployments have a combined environment update endpoint for chainlet settings (instance types, autoscaling).
+- **Rolling deployments are not supported for Chains** — promotion is an immediate traffic swap.
 
 ## Gotchas
 
-- **`production` endpoints and environment endpoints are different surfaces.**
+- **`production` endpoints vs environment endpoints differ.**
   `/v1/models/{id}/deployments/production/...` addresses the production deployment directly;
-  `/v1/models/{id}/environments/{env_name}/...` addresses an environment (which production is one of). Pick the right
-  one for the intended operation.
-- **Rolling deployments suspend autoscaling** for the environment for their whole duration; PATCHing autoscaling
-  mid-rollout will not behave as expected.
-- **Only one active promotion per environment at a time.** Subsequent promotion requests are rejected until the current
-  one completes, pauses, or is cancelled.
+  `/v1/models/{id}/environments/{env_name}/...` addresses an environment (production is one). Pick the right one.
+- **Rolling deployments suspend autoscaling** for the environment for their duration; PATCHing mid-rollout won't behave
+  as expected.
+- **One active promotion per environment at a time.** Subsequent requests rejected until the current one
+  completes/pauses/cancels.
 - **Production cannot be deleted** unless the model itself is deleted.
-- **Deleted deployments and environments return 404** for subsequent API calls; deactivation is the reversible option.
-- **Secrets API upserts by name.** Reusing a name overwrites the existing secret's value.
-- **Authorization errors come back as 401 with `Api-Key` prefix stripped or malformed.** Double-check the prefix and the
-  exact header name if a valid-looking key is being rejected.
+- **Deleted deployments / environments → 404** on subsequent calls; deactivation is the reversible option.
+- **Secrets API upserts by name.** Reusing a name overwrites the existing value.
+- **401s on a valid-looking key** are almost always the `Api-Key` prefix being malformed or replaced with `Bearer`.
+  Custom-deployment inference endpoints use `Api-Key` too; Model APIs use `Bearer`. Don't generalize.
 
 ## Further reading
 

--- a/skills/baseten/references/management-api.md
+++ b/skills/baseten/references/management-api.md
@@ -11,9 +11,8 @@ The `truss` CLI uses this API under the hood for push and promotion operations.
 
 1. **`baseten` MCP** (preferred).
 2. If MCP not installed → in interactive sessions, offer install (SKILL.md "Agent DX Toolkit")
-3. Otherwise fall back **REST API**
-   Spec: <https://api.baseten.co/v1/spec>. Overview: <https://docs.baseten.co/reference/management-api/overview>.
-   Non-trivial integrations → generate from the spec.
+3. Otherwise fall back **REST API** Spec: <https://api.baseten.co/v1/spec>. Overview:
+   <https://docs.baseten.co/reference/management-api/overview>. Non-trivial integrations → generate from the spec.
 
 ### Authentication
 
@@ -29,8 +28,8 @@ All paths under `/v1`:
 
 - **Models** / **Chains**: list, get, delete.
 - **Deployments**: list, get, delete, activate, deactivate, retry, promote, terminate replica.
-- **Environments**: create, list, get, update (autoscaling, settings). Rolling deployment controls
-  (`pause_promotion`, `resume_promotion`, `force_*`, `cancel_promotion`) live on the environment path.
+- **Environments**: create, list, get, update (autoscaling, settings). Rolling deployment controls (`pause_promotion`,
+  `resume_promotion`, `force_*`, `cancel_promotion`) live on the environment path.
 - **Autoscaling**: PATCH on deployment / environment.
 - **Instance types**: `/v1/instance_types`, `/v1/instance_type_prices` — authoritative valid-resources list for
   `config.yaml`.
@@ -72,9 +71,9 @@ Chain management mirrors models with `/v1/chains/...`. Notable:
 
 ## Gotchas
 
-- **`production` endpoints vs environment endpoints differ.**
-  `/v1/models/{id}/deployments/production/...` addresses the production deployment directly;
-  `/v1/models/{id}/environments/{env_name}/...` addresses an environment (production is one). Pick the right one.
+- **`production` endpoints vs environment endpoints differ.** `/v1/models/{id}/deployments/production/...` addresses the
+  production deployment directly; `/v1/models/{id}/environments/{env_name}/...` addresses an environment (production is
+  one). Pick the right one.
 - **Rolling deployments suspend autoscaling** for the environment for their duration; PATCHing mid-rollout won't behave
   as expected.
 - **One active promotion per environment at a time.** Subsequent requests rejected until the current one


### PR DESCRIPTION
## Summary

Two additions to `SKILL.md` / `references/management-api.md` validated against an eval sweep across multiple toolkit configurations:

- **`list_library_models` gotcha**: clarify what the curated catalog actually is (~tens of pre-optimized hosted models, mostly popular open-source LLMs / embeddings). Useful for getting started, not for custom authoring / finetuning / private HF repos.
- **New section `MCP introspection vs. invocation`**: distinguishes lookup tasks (MCP get/list is the right starting point) from behavior tasks (where exercising the endpoint yourself with `curl` is the test that actually answers the question). Notes that log windows are bounded so "no recent errors" is not proof a reported bug is gone — and that log tools support custom time ranges within retention for historic incidents.
- **`references/management-api.md`**: tighten the call-channel order (MCP first, fall back to REST), drop verbose curl examples that duplicated docs, trim the resource-shape walkthrough.

## Test plan

- [ ] Skim diffs; no behavioral change to anything other than skill content.
- [ ] Skill is exercised in the companion eval PR (#eval-final) and the new guidance is reflected in measurable wall/cost reductions on backend-heavy tasks.