### PR TITLE
docs: rework install (agent-driven + Windows) + default to uv tool install truss

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Install the Baseten agent toolkit following instructions from `github.com/basete
 
 - use `npx skills add` and `npx add-mcp`
 - all global and for all agents (`-g -y`)
-- The baseten backend server needs auth header `Authorization: Bearer $BASETEN_MCP_KEY`. Run the commands through the shell (Bash tool) so it expands the env var; don't read or inline the key value. User must have `BASETEN_MCP_KEY` set in the shell.
+- The baseten backend server needs auth header `Authorization: Bearer $BASETEN_MCP_KEY` (or `Authorization: Bearer $env:BASETEN_MCP_KEY` in PowerShell). Run the install commands in a shell that has `BASETEN_MCP_KEY` set so the env var expands; don't read or inline the key value.
 ```
 
 #### Manual

--- a/README.md
+++ b/README.md
@@ -27,29 +27,60 @@ What you can do without leaving the chat:
 
 ### Installation
 
+#### Agent-driven (recommended)
+
+Set your key, then paste this into your agent:
+
+Linux/Mac:
 ```bash
 export BASETEN_MCP_KEY=...
-
-{ [ -n "$BASETEN_MCP_KEY" ] && [ "$BASETEN_MCP_KEY" != "..." ]; } || { echo "Error: set BASETEN_MCP_KEY first"; false; } && \
-npx add-mcp https://api.baseten.co/mcp -g -y --header "Authorization: Bearer ${BASETEN_MCP_KEY}" && \
-npx add-mcp https://docs.baseten.co/mcp -n "baseten_docs" -g -y && \
-npx skills add basetenlabs/baseten-skills -g -y
 ```
 
-- `-g` installs it globally on your host.
-- `-y` confirms selection for all detected harnesses.
-- If your harness supports env variable interpolation, you may also edit the MCP config file to expand your env vars
-  and set the desired key in the shell that starts the agent.
+Windows:
+```powershell
+$env:BASETEN_MCP_KEY = "..."
+```
 
-The `truss` CLI is separate and needed only for deployment authoring (not pure ops work). See [CLI docs](https://docs.baseten.co/reference/cli/truss/overview).
-E.g. if you use pip (similar for other package
-managers):
+Then paste this into the agent of your choice
+```
+Install the Baseten agent toolkit following instructions from `github.com/basetenlabs/baseten-skills`.
+
+- use `npx skills add` and `npx add-mcp`
+- all global and for all agents (`-g -y`)
+- The baseten backend server needs auth header `Authorization: Bearer $BASETEN_MCP_KEY`. Run the commands through the shell (Bash tool) so it expands the env var; don't read or inline the key value. User must have `BASETEN_MCP_KEY` set in the shell.
+```
+
+#### Manual
+
+Linux/Mac:
+```bash
+export BASETEN_MCP_KEY=...
+npx skills add basetenlabs/baseten-skills -g -y
+npx add-mcp https://api.baseten.co/mcp -g -y --header "Authorization: Bearer ${BASETEN_MCP_KEY}"
+npx add-mcp https://docs.baseten.co/mcp -n "baseten_docs" -g -y
+```
+
+Windows:
+```powershell
+$env:BASETEN_MCP_KEY = "..."
+npx skills add basetenlabs/baseten-skills -g -y
+npx add-mcp https://api.baseten.co/mcp -g -y --header "Authorization: Bearer $env:BASETEN_MCP_KEY"
+npx add-mcp https://docs.baseten.co/mcp -n "baseten_docs" -g -y
+```
+
+- `-g` global, `-y` auto-confirms all detected harnesses.
+- Harnesses that support env-var interpolation: point the MCP config at `$BASETEN_MCP_KEY` instead of baking the key in.
+- Some agents prompt before reading skill reference files (they live outside your workspace). In Claude Code,
+  pre-approve via `settings.json`: `"permissions": { "allow": ["Read(~/.claude/skills/**)"] }`.
+
+The `truss` CLI is separate, needed for deployment authoring; see
+[CLI docs](https://docs.baseten.co/reference/cli/truss/overview):
 
 ```bash
-pip install truss --upgrade
+uv tool install truss
 ```
 
-You can install only part of the components or modify commands - but the best user experience comes from their combination.
+Components (skill, 2x MCPs, CLI) can be installed selectively, but work best in combination.
 
 ## Getting started & Usage
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Windows:
 $env:BASETEN_MCP_KEY = "..."
 ```
 
-Then paste this into the agent of your choice
+Then paste this into the agent of your choice:
 ```
 Install the Baseten agent toolkit following instructions from `github.com/basetenlabs/baseten-skills`.
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,10 @@ Linux/Mac:
 export BASETEN_MCP_KEY=...
 ```
 
-Windows:
+Windows (PowerShell or cmd.exe):
 ```powershell
-$env:BASETEN_MCP_KEY = "..."
+$env:BASETEN_MCP_KEY = "..."   # PowerShell
+set BASETEN_MCP_KEY=...         # cmd.exe
 ```
 
 Then paste this into the agent of your choice:

--- a/skills/baseten/SKILL.md
+++ b/skills/baseten/SKILL.md
@@ -26,7 +26,7 @@ cross-cloud HA, and seamless developer workflows.
 | --- | --- | --- |
 | `baseten` MCP | Interact with backend (~REST API, CRUD): models, deployments, training, environments, secrets, chains. API-key auth. | `npx add-mcp https://api.baseten.co/mcp -g -y --header "Authorization: Bearer ${BASETEN_MCP_KEY}"` |
 | `baseten_docs` MCP | Semantic search + filesystem of `docs.baseten.co`. No auth. | `npx add-mcp https://docs.baseten.co/mcp -n "baseten_docs" -g -y` |
-| `truss` CLI | Needed for model/chain push from local code, watch (= live patch). Needs `truss login` once. | `pip install truss --upgrade` (respect user package manager: uv, poetry...) |
+| `truss` CLI | Needed for model/chain push from local code, watch (= live patch). Needs `truss login` once. | `uv tool install truss` (or `pip install truss --upgrade`; respect user package manager: uv, poetry...) |
 | `llms.txt` | `baseten.co/llms.txt` (product + blog), `docs.baseten.co/llms.txt` (docs). | reachable via HTTP |
 | This skill | `SKILL.md` + `references/*.md` loaded on demand. | `npx skills add basetenlabs/baseten-skills -g -y` |
 


### PR DESCRIPTION
## Summary

Install-docs fixes from the MCP bug bash:

- **Agent-driven install path** (recommended, OS-agnostic): set the key in an env var, paste a prompt into your coding agent. Solves Windows without a hand-maintained translation.
- **Explicit manual blocks** for macOS/Linux and **PowerShell** (Windows was previously unsupported). Skill is no longer installed last.
- Dropped placeholder-key guards and `&&` chaining; tightened the prose (cut hand-holding).
- Noted the `Read(~/.claude/skills/**)` allow-rule so skill-reference reads don't prompt.
- Default truss install to `uv tool install truss` (pip as alternative) in README + SKILL.md toolkit table.

## Test plan

- [x] `pre-commit` markdown preprocessor passes on `SKILL.md` / `README.md`
- [x] No behavioral skill change (only the truss-install line in SKILL.md), so no eval re-run