### PR TITLE
fix(baseten skill): correct truss CLI auth/remote/output-format docs

### DIFF
--- a/skills/baseten/references/deployment-lifecycle.md
+++ b/skills/baseten/references/deployment-lifecycle.md
@@ -136,7 +136,7 @@ Programmatic equivalents live in `management-api.md`.
 
 ## CI/CD
 
-The normal CI/CD shape is `truss push` with some mix of `--wait`, `--tail`, `--json`, `--environment`,
+The normal CI/CD shape is `truss push` with some mix of `--wait`, `--tail`, `--output json`, `--environment`,
 `--include-git-info`, and `--labels`. See `truss-cli.md` for specifics. <https://docs.baseten.co/deployment/ci-cd> has
 worked examples.
 

--- a/skills/baseten/references/truss-cli.md
+++ b/skills/baseten/references/truss-cli.md
@@ -16,12 +16,44 @@ the user's preferred package manager.
 
 ## Authenticate
 
+`truss login` is a top-level alias for `truss auth login`; both accept `--browser`, `--api-key TEXT`, and
+`--remote TEXT`.
+
 ```
 truss login
 ```
 
-Paste an API key from <https://app.baseten.co/settings/api_keys> when prompted. Truss stores credentials in `.trussrc`
-for future commands. In CI, set `BASETEN_API_KEY` and use `--remote` to select the saved remote name.
+In an interactive terminal, this prompts you to either paste an API key from <https://app.baseten.co/settings/api_keys>
+or log in via browser (OAuth). Pass `--browser` to start the OAuth device flow directly, or pass `--api-key TEXT` to
+authenticate with an API key; the two flags are mutually exclusive.
+
+In a non-interactive run, you must pass one of those flags explicitly. Otherwise, Truss errors with:
+
+```
+Specify --browser or --api-key when running non-interactively.
+```
+
+In CI, set `BASETEN_API_KEY` and use `--remote` to select the saved remote name; Truss falls back to that env var when
+the saved remote has no stored key. To create the remote itself non-interactively, run
+`truss login --api-key "$BASETEN_API_KEY"` — `--api-key` is a `login` flag, not a `push` flag. Verify the active remote
+with:
+
+```
+truss auth status
+```
+
+Sample output:
+
+```
+remote: baseten
+remote_url: https://app.baseten.co
+auth_type: api_key (plaintext)
+source: trussrc-inline
+```
+
+When only one remote is configured, `--remote <name>` is inferred. With multiple remotes in `.trussrc`, pass it
+explicitly or the command errors with `Multiple remotes available. Please specify one with --remote.` The `source` field
+is `trussrc-inline` for credentials stored in `.trussrc` and `keyring` for credentials stored in the OS keyring.
 
 ## `truss init` - scaffold
 
@@ -66,7 +98,7 @@ truss push --wait --tail
 CI-friendly publish with machine-readable output (intended for automation):
 
 ```
-truss push --json --wait
+truss push --output json --wait
 ```
 
 Promote straight to production:
@@ -98,7 +130,8 @@ truss push --environment staging
 - `--model-name <name>`: temporarily override `model_name` without editing `config.yaml`.
 - `--wait` / `--no-wait`: block until the deploy finishes; exit non-zero on failure.
 - `--tail`: stream deployment logs after push. Combines with `--wait` and with `--watch`.
-- `--json`: emit structured output suitable for CI parsing.
+- `--output [text|json]`: select the output format. `json` writes structured JSON to stdout and progress and logs to
+  stderr, which is suitable for CI parsing.
 - `--labels '{"k":"v"}'`: attach searchable key/value labels to the deployment.
 - `--include-git-info`: attach git sha, branch, and tag.
 - `--no-cache`: force a full rebuild without using cached layers.
@@ -145,8 +178,10 @@ Fetches recent logs for a deployment. For continuous streaming during a push, pr
 
 ## `truss configure`, `truss whoami`, `truss cleanup`
 
-Workspace and account utilities. `whoami` prints the current authenticated user. `configure` manages remotes in
-`.trussrc`. `cleanup` removes locally cached deployment artifacts.
+Workspace and account utilities. `whoami` prints the current authenticated user. `configure` opens `$EDITOR` on
+`~/.trussrc` via `click.edit()` and blocks until the editor exits. Use `truss login` / `truss auth login` to add a
+remote and `truss auth logout` to remove one without opening an editor. `cleanup` removes locally cached deployment
+artifacts.
 
 ## Gotchas
 
@@ -156,6 +191,10 @@ Workspace and account utilities. `whoami` prints the current authenticated user.
   Stop the watch (or accept the cost) accordingly.
 - **`--watch-hot-reload` does not re-run `__init__` or `load`.** If your change relies on new state set up there, do a
   full reload (omit `--watch-hot-reload`) instead.
+- **Bare `truss login` errors in a non-interactive run.** Pass either `--browser` or `--api-key`; otherwise it errors
+  with `Specify --browser or --api-key when running non-interactively.`
+- **`truss configure` blocks on `$EDITOR`.** It opens `~/.trussrc` via `click.edit()` and waits for the editor to exit,
+  so do not run it from a non-interactive agent.
 - **`.trussrc` holds credentials.** Do not commit it. In CI / scripted flows, prefer `BASETEN_API_KEY` plus
   `--remote <name>` over committing `.trussrc`. Truss is moving toward OS keyring storage; if asking for a key, ask the
   user to export it as an env var rather than reading or writing credential files yourself.


### PR DESCRIPTION
`skills/baseten/references/truss-cli.md` documents commands and flags that do not exist, so an agent following it cannot complete a basic install → authenticate → verify-remote task. All facts below were verified by running the CLI (truss 0.18.21) and reading the installed `truss.cli` source.

Three concrete errors:

1. **`truss push --json` does not exist.** It errors with `No such option '--json'.` The real flag is `--output [text|json]`, where `json` emits structured JSON to stdout and sends progress/logs to stderr. Fixed in `truss-cli.md` (example + flag list) and in the one occurrence in `deployment-lifecycle.md`.
2. **`truss auth status` was undocumented.** It is the command that answers "verify the active remote", printing `remote` / `remote_url` / `auth_type` / `source`. `--remote` is inferred with a single remote and required with several. There is no `truss remote` command (`No such command 'remote'`).
3. **`truss login --browser` was undocumented.** `truss login` is an alias for `truss auth login`; both take `--browser` (OAuth device flow) and `--api-key`. With neither flag and no TTY, truss errors `Specify --browser or --api-key when running non-interactively.` — a bare `truss login` is a hard failure for a headless agent, so the flags are now called out explicitly.

Also corrected: `truss configure` was described as managing remotes in `.trussrc`. It opens `$EDITOR` on `~/.trussrc` via `click.edit()` and blocks until the editor exits, which hangs a non-interactive agent. The section now says so and points at `truss login` / `truss auth logout` instead.

Motivating context: an external evaluation of the Baseten agent toolkit surfaced this reference as the blocker on its first task.

Docs only, no behavior change.